### PR TITLE
Correctly turn uint128_t into float_128t

### DIFF
--- a/src/c/coverfloat.h
+++ b/src/c/coverfloat.h
@@ -83,8 +83,8 @@ typedef struct {
 #define UINT128_TO_FLOAT32(f, x)  (f.v = (uint32_t) (x->lower & 0xFFFFFFFF))
 #define UINT128_TO_FLOAT64(f, x)  (f.v = (uint64_t) (x->lower))
 #define UINT128_TO_FLOAT128(f, x) do {                    \
-                                       f.v[0] = x->upper; \
-                                       f.v[1] = x->lower; \
+                                       f.v[1] = x->upper; \
+                                       f.v[0] = x->lower; \
                                      } while (0)
 
 #define FLOAT16_TO_UINT128(x, f)  do {                    \
@@ -103,8 +103,8 @@ typedef struct {
                                      } while (0)
 
 #define FLOAT128_TO_UINT128(x, f) do {                    \
-                                       x->upper = f.v[0]; \
-                                       x->lower = f.v[1]; \
+                                       x->upper = f.v[1]; \
+                                       x->lower = f.v[0]; \
                                      } while (0)
 
 void softFloat_clearFlags( uint_fast8_t );


### PR DESCRIPTION
The macros converting to float128_t were backwards.

These are the relevant types in softfloat:
```c
typedef struct { uint64_t v[2]; } float128_t;
```

```c
union ui128_f128 { struct uint128 ui; float128_t f; };
```

```c
struct uint128 { uint64_t v0, v64; };
```

And it is normally extracted from float128_t like this:

```c
float128_t f128_mulAdd( float128_t a, float128_t b, float128_t c )
{
    union ui128_f128 uA;
    uint_fast64_t uiA64, uiA0;
    
    // ...

    uA.f = a;
    uiA64 = uA.ui.v64;
    uiA0  = uA.ui.v0;
    // ...
}
```

The v64 is supposed to be the upper 64 bits and the v0 is the lower 64 bits, so that is why they have to be swapped in the macros. Let me know if this is wrong, but it seemed to fix some weird quad errors I was getting, and brought up coverage on B1 by 50 bins. 