### PR TITLE
Contain/Beautify Logging For Each Model + Refactor cli.py to be more sane

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "rich==14.1.0",
     "sympy==1.14.0",
-    "tqdm==4.67.3",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "sympy==1.14.0",
+    "tqdm==4.67.3",
 ]
 
 [project.scripts]

--- a/src/cover_float/cli.py
+++ b/src/cover_float/cli.py
@@ -1,9 +1,13 @@
 import argparse
+import logging
 from pathlib import Path
 
+import cover_float.common.log as log
 import cover_float.testgen as tg
 from cover_float.reference import run_test_vector
 from cover_float.scripts.parse_testvectors import format_output, parse_test_vector
+
+logging.basicConfig(level=logging.INFO)
 
 
 def main() -> None:
@@ -57,10 +61,11 @@ def testgen() -> None:
 
     output_dir = Path(args.output_dir)
 
-    if args.models is None:
-        for model in tg.model.GLOBAL_MODELS:
-            tg.model.GLOBAL_MODELS[model](output_dir)
-    else:
-        for model in args.models:
-            if model in tg.model.GLOBAL_MODELS:
-                tg.model.GLOBAL_MODELS[model](output_dir)
+    with log.StatusReporter() as logger:  # , ProcessPoolExecutor() as executor:
+        if args.models is None:
+            for model in tg.model.GLOBAL_MODELS:
+                tg.model.GLOBAL_MODELS[model](output_dir, logger)
+        else:
+            for model in args.models:
+                if model in tg.model.GLOBAL_MODELS:
+                    tg.model.GLOBAL_MODELS[model](output_dir, logger)

--- a/src/cover_float/cli.py
+++ b/src/cover_float/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import cover_float.common.log as log
@@ -61,11 +62,11 @@ def testgen() -> None:
 
     output_dir = Path(args.output_dir)
 
-    with log.StatusReporter() as logger:  # , ProcessPoolExecutor() as executor:
+    with log.StatusReporter() as logger, ProcessPoolExecutor() as executor:
         if args.models is None:
             for model in tg.model.GLOBAL_MODELS:
-                tg.model.GLOBAL_MODELS[model](output_dir, logger)
+                tg.model.GLOBAL_MODELS[model](output_dir, logger, executor)
         else:
             for model in args.models:
                 if model in tg.model.GLOBAL_MODELS:
-                    tg.model.GLOBAL_MODELS[model](output_dir, logger)
+                    tg.model.GLOBAL_MODELS[model](output_dir, logger, executor)

--- a/src/cover_float/cli.py
+++ b/src/cover_float/cli.py
@@ -55,100 +55,12 @@ def testgen() -> None:
     parser.add_argument("--output-dir", type=str, default="tests", help="Directory to save generated test vectors")
     args = parser.parse_args()
 
+    output_dir = Path(args.output_dir)
+
     if args.models is None:
-        tg.B1.main()
-        auto_parse("B1", args.output_dir)
-        tg.B2.main()
-        auto_parse("B2", args.output_dir)
-        tg.B3.main()
-        auto_parse("B3", args.output_dir)
-        tg.B6.main()
-        auto_parse("B6", args.output_dir)
-        tg.B7.main()
-        auto_parse("B7", args.output_dir)
-        tg.B8.main()
-        auto_parse("B8", args.output_dir)
-        tg.B9.main()
-        auto_parse("B9", args.output_dir)
-        tg.B10.main()
-        auto_parse("B10", args.output_dir)
-        tg.B11.main()
-        auto_parse("B11", args.output_dir)
-        tg.B12.main()
-        auto_parse("B12", args.output_dir)
-        tg.B13.main()
-        auto_parse("B13", args.output_dir)
-        tg.B14.main()
-        auto_parse("B14", args.output_dir)
-        tg.B15.main()
-        auto_parse("B15", args.output_dir)
-        tg.B20.main()
-        auto_parse("B20", args.output_dir)
-        tg.B21.main()
-        auto_parse("B21", args.output_dir)
-        tg.B25.main()
-        auto_parse("B25", args.output_dir)
-        tg.B26.main()
-        auto_parse("B26", args.output_dir)
-        tg.B27.main()
-        auto_parse("B27", args.output_dir)
-        tg.B29.main()
-        auto_parse("B29", args.output_dir)
+        for model in tg.model.GLOBAL_MODELS:
+            tg.model.GLOBAL_MODELS[model](output_dir)
     else:
-        if "B1" in args.models:
-            tg.B1.main()
-            auto_parse("B1", args.output_dir)
-        if "B2" in args.models:
-            tg.B2.main()
-            auto_parse("B2", args.output_dir)
-        if "B3" in args.models:
-            tg.B3.main()
-            auto_parse("B3", args.output_dir)
-        if "B6" in args.models:
-            tg.B6.main()
-            auto_parse("B6", args.output_dir)
-        if "B7" in args.models:
-            tg.B7.main()
-            auto_parse("B7", args.output_dir)
-        if "B8" in args.models:
-            tg.B8.main()
-            auto_parse("B8", args.output_dir)
-        if "B9" in args.models:
-            tg.B9.main()
-            auto_parse("B9", args.output_dir)
-        if "B10" in args.models:
-            tg.B10.main()
-            auto_parse("B10", args.output_dir)
-        if "B11" in args.models:
-            tg.B11.main()
-            auto_parse("B11", args.output_dir)
-        if "B12" in args.models:
-            tg.B12.main()
-            auto_parse("B12", args.output_dir)
-        if "B13" in args.models:
-            tg.B13.main()
-            auto_parse("B13", args.output_dir)
-        if "B14" in args.models:
-            tg.B14.main()
-            auto_parse("B14", args.output_dir)
-        if "B15" in args.models:
-            tg.B15.main()
-            auto_parse("B15", args.output_dir)
-        if "B20" in args.models:
-            tg.B20.main()
-            auto_parse("B20", args.output_dir)
-        if "B21" in args.models:
-            tg.B21.main()
-            auto_parse("B21", args.output_dir)
-        if "B25" in args.models:
-            tg.B25.main()
-            auto_parse("B25", args.output_dir)
-        if "B26" in args.models:
-            tg.B26.main()
-            auto_parse("B26", args.output_dir)
-        if "B27" in args.models:
-            tg.B27.main()
-            auto_parse("B27", args.output_dir)
-        if "B29" in args.models:
-            tg.B29.main()
-            auto_parse("B29", args.output_dir)
+        for model in args.models:
+            if model in tg.model.GLOBAL_MODELS:
+                tg.model.GLOBAL_MODELS[model](output_dir)

--- a/src/cover_float/cli.py
+++ b/src/cover_float/cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import cover_float.common.log as log
 import cover_float.testgen as tg
+from cover_float.common.util import SingleThreadedExecutor
 from cover_float.reference import run_test_vector
 from cover_float.scripts.parse_testvectors import format_output, parse_test_vector
 
@@ -58,11 +59,20 @@ def testgen() -> None:
         help="Model(s) to generate test vectors for",
     )
     parser.add_argument("--output-dir", type=str, default="tests", help="Directory to save generated test vectors")
+    parser.add_argument("--single-thread", action="store_true", help="Run Generation in a Single Thread")
+    parser.add_argument("--jobs", type=int, default=None, help="Number of Jobs to Run When Multi-Threaded")
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
 
-    with log.StatusReporter() as logger, ProcessPoolExecutor() as executor:
+    single_thread = args.single_thread or (args.models is not None and len(args.models) < 2)
+
+    if single_thread:
+        executor = SingleThreadedExecutor()
+    else:
+        executor = ProcessPoolExecutor() if args.jobs is None else ProcessPoolExecutor(max_workers=args.jobs)
+
+    with log.StatusReporter() as logger, executor:
         if args.models is None:
             for model in tg.model.GLOBAL_MODELS:
                 tg.model.GLOBAL_MODELS[model](output_dir, logger, executor)

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator, Iterable
+import logging.handlers
+import multiprocessing
+import threading
+import time
+from collections.abc import Generator, Iterable, Sized
 from contextlib import contextmanager
+from queue import Queue
 from types import TracebackType
 from typing import Any, Callable, TypeVar
 
@@ -24,7 +29,8 @@ logging.addLevelName(STATUS_LEVEL_NUM, "STATUS")
 
 
 class ModelLogger(logging.Logger):
-    status_reporter: StatusReporter
+    task_id: TaskID
+    msg_queue: Queue[Any]
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
@@ -32,6 +38,22 @@ class ModelLogger(logging.Logger):
     def status(self, message: str, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         if self.isEnabledFor(STATUS_LEVEL_NUM):
             self._log(STATUS_LEVEL_NUM, message, args, **kwargs)
+
+    @contextmanager
+    def progress_bar(
+        self, model_name: str, status: str | None = None, *, total: float | None = 100, show_m_of_n: bool = False
+    ) -> Generator[BarHandle, None, None]:
+        handle = BarHandle(self.msg_queue, self.task_id)
+
+        if status is not None:
+            handle.update(total=total, completed=0, status=status, m_of_n=show_m_of_n)
+        else:
+            handle.update(total=total, completed=0, m_of_n=show_m_of_n)
+
+        try:
+            yield handle
+        finally:
+            handle.update(total=None, completed=0, m_of_n=False)
 
 
 logging.setLoggerClass(ModelLogger)
@@ -51,13 +73,14 @@ T = TypeVar("T")
 
 
 class BarHandle:
-    def __init__(self, progress: Progress, task_id: TaskID) -> None:
-        self._progress = progress
+    def __init__(self, queue: Queue[Any], task_id: TaskID) -> None:
+        self._queue = queue
         self._task_id = task_id
 
     # Match Progress.advance exactly
     def advance(self, advance: float = 1) -> None:
-        self._progress.advance(self._task_id, advance)
+        # self._progress.advance(self._task_id, advance)
+        self._queue.put({"action": "advance", "args": [self._task_id, advance], "kwargs": {}})
 
     # Match Progress.update exactly — forward all kwargs through
     def update(
@@ -71,15 +94,31 @@ class BarHandle:
         refresh: bool = False,
         **fields: Any,  # noqa: ANN401
     ) -> None:
-        self._progress.update(
-            self._task_id,
-            total=total,
-            completed=completed,
-            advance=advance,
-            description=description,
-            visible=visible,
-            refresh=refresh,
-            **fields,
+        # self._progress.update(
+        #     self._task_id,
+        #     total=total,
+        #     completed=completed,
+        #     advance=advance,
+        #     description=description,
+        #     visible=visible,
+        #     refresh=refresh,
+        #     **fields,
+        # )
+
+        self._queue.put(
+            {
+                "action": "update",
+                "args": [self._task_id],
+                "kwargs": {
+                    "total": total,
+                    "completed": completed,
+                    "advance": advance,
+                    "description": description,
+                    "visible": visible,
+                    "refresh": refresh,
+                    **fields,
+                },
+            }
         )
 
     def track(
@@ -88,17 +127,30 @@ class BarHandle:
         *,
         total: float | None = None,
         completed: int = 0,
-        description: str = "",
         update_period: float = 0.1,
     ) -> Iterable[T]:
-        return self._progress.track(
-            sequence,
-            task_id=self._task_id,
-            description=description,
-            total=total,
-            completed=completed,
-            update_period=update_period,
-        )
+        # return self._progress.track(
+        #     sequence,
+        #     task_id=self._task_id,
+        #     description=description,
+        #     total=total,
+        #     completed=completed,
+        #     update_period=update_period,
+        # )
+
+        if total is None and isinstance(sequence, Sized):
+            total = len(sequence)
+
+        last_update = time.monotonic() - update_period
+
+        for x in sequence:
+            yield x
+
+            now = time.monotonic()
+            completed += 1
+            if now - last_update >= update_period:
+                self.update(total=total, completed=completed)
+                last_update = now
 
 
 class OptionalColumn(ProgressColumn):
@@ -113,16 +165,53 @@ class OptionalColumn(ProgressColumn):
         return self._real_col.render(task)
 
 
+class LoggingHandler(logging.Handler):
+    def __init__(self, reporter: StatusReporter, model_name: str) -> None:
+        super().__init__()
+        self.reporter = reporter
+        self.model_name = model_name
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.reporter.status_update(self.model_name, record.msg)
+
+
+class AsyncLoggingHandler:
+    _SENTINEL = None
+
+    def __init__(self, reporter: StatusReporter, listen_to: Queue[Any]) -> None:
+        self.reporter = reporter
+        self.monitor_thread: threading.Thread | None = None
+        self.listen_to = listen_to
+
+    def start(self) -> None:
+        self.monitor_thread = threading.Thread(target=self.monitor_fn, daemon=True)
+        self.monitor_thread.start()
+
+    def stop(self) -> None:
+        self.listen_to.put(self._SENTINEL)
+        if self.monitor_thread:
+            self.monitor_thread.join()
+            self.monitor_thread = None
+
+    def monitor_fn(self) -> None:
+        while True:
+            record = self.listen_to.get(block=True)
+            if record is self._SENTINEL:
+                break
+
+            try:
+                action = record["action"]
+                if action == "update":
+                    self.reporter.progress.update(*record["args"], **record["kwargs"])
+                elif action == "advance":
+                    self.reporter.progress.advance(*record["args"], **record["kwargs"])
+                else:
+                    logging.info(f"Failed to Log {record}")
+            except Exception as e:
+                logging.info(f"Failed to Log {record}", exc_info=e)
+
+
 class StatusReporter:
-    class _LoggingHandler(logging.Handler):
-        def __init__(self, reporter: StatusReporter, model_name: str) -> None:
-            super().__init__()
-            self.reporter = reporter
-            self.model_name = model_name
-
-        def emit(self, record: logging.LogRecord) -> None:
-            self.reporter.status_update(self.model_name, record.msg)
-
     def __init__(self) -> None:
         self.active_status_bars: dict[str, TaskID] = {}
         self.progress = Progress(
@@ -134,33 +223,34 @@ class StatusReporter:
             OptionalColumn(lambda t: t.total is not None, TextColumn("{task.percentage:>3.0f}%")),
         )
 
+        self.manager = multiprocessing.Manager()
+
+        self.progress_queue = self.manager.Queue()
+        self.logging_queue = self.manager.Queue()
+
+        # This is the actual handler that prints to console
+        self.rich_handler = RichHandler(show_time=True, markup=True)
+        self.queue_listener = logging.handlers.QueueListener(self.logging_queue, self.rich_handler)
+        logging.getLogger().addHandler(self.rich_handler)
+        logging.getLogger().propagate = False
+
+        self.progress_listener = AsyncLoggingHandler(self, self.progress_queue)
+
     def __enter__(self) -> StatusReporter:
         self.progress.start()
+        self.queue_listener.start()
+        self.progress_listener.start()
         return self
 
     def __exit__(self, exc_type: type | None, exc_value: Exception | None, traceback: TracebackType | None) -> None:
+        self.queue_listener.stop()
+        self.progress_listener.stop()
         self.progress.stop()
 
-    def start_model(self, model_name: str) -> None:
+    def start_model(self, model_name: str) -> TaskID:
         task_id = self.progress.add_task(f"{model_name}: ", status="Test Generation", total=None)
         self.active_status_bars[model_name] = task_id
-        model_logger = logging.getLogger(model_name)
-
-        if isinstance(model_logger, ModelLogger):
-            model_logger.status_reporter = self
-
-        model_logger.handlers = []
-        model_logger.propagate = False
-
-        # Handle Status Updates
-        handler = self._LoggingHandler(self, model_name)
-        handler.addFilter(OnlyStatusFilter())
-        model_logger.addHandler(handler)
-
-        # Handle Other Updates
-        general_handler = RichHandler()
-        general_handler.addFilter(ExcludeStatusFilter())
-        model_logger.addHandler(general_handler)
+        return task_id
 
     def stop_model(self, model_name: str) -> None:
         self.progress.remove_task(self.active_status_bars[model_name])
@@ -169,19 +259,3 @@ class StatusReporter:
     def status_update(self, model_name: str, status_message: str) -> None:
         task = self.active_status_bars[model_name]
         self.progress.update(task, status=status_message)
-
-    @contextmanager
-    def progress_bar(
-        self, model_name: str, status: str | None = None, *, total: float | None = 100, show_m_of_n: bool = False
-    ) -> Generator[BarHandle, None, None]:
-        task_id = self.active_status_bars[model_name]
-
-        if status is not None:
-            self.progress.update(task_id, total=total, completed=0, status=status, m_of_n=show_m_of_n)
-        else:
-            self.progress.update(task_id, total=total, completed=0, m_of_n=show_m_of_n)
-
-        try:
-            yield BarHandle(self.progress, task_id)
-        finally:
-            self.progress.update(task_id, total=None, completed=0, m_of_n=False)

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -1,90 +1,187 @@
 from __future__ import annotations
 
-import io
-import os
-from collections.abc import Iterable
-from typing import Any, TypeVar, overload
+import logging
+from collections.abc import Generator, Iterable
+from contextlib import contextmanager
+from types import TracebackType
+from typing import Any, Callable, TypeVar
 
-import tqdm
+from rich import console
+from rich.logging import RichHandler
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    ProgressColumn,
+    SpinnerColumn,
+    Task,
+    TaskID,
+    TextColumn,
+)
 
-
-class LoggingContext(io.TextIOBase):
-    def __init__(self, prefix: str) -> None:
-        super().__init__()
-        self.prefix = prefix
-        self.error_count = 0
-        self.last_print = ""
-
-        self.write("")
-
-    def write(self, s: str) -> int:
-        processed_string = s.strip("\r").replace("\n", "\r\033[K")
-        print("\033[K" + self.prefix + processed_string, end="\r")
-        self.last_print = s
-
-        return len(s)
-
-    def flush(self) -> None:
-        pass
-
-    def isatty(self) -> bool:
-        return True
-
-    def increase_error_count(self) -> None:
-        self.error_count += 1
-
-    def set_prefix(self, prefix: str) -> None:
-        self.prefix = prefix
-        self.write("")
-
-    def print_error(self, error: str) -> None:
-        print(self.prefix + error)
-        self.write(self.last_print)
+STATUS_LEVEL_NUM = 25
+logging.addLevelName(STATUS_LEVEL_NUM, "STATUS")
 
 
-_the_logging_context = LoggingContext("")
+class ModelLogger(logging.Logger):
+    status_reporter: StatusReporter
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+
+    def status(self, message: str, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        if self.isEnabledFor(STATUS_LEVEL_NUM):
+            self._log(STATUS_LEVEL_NUM, message, args, **kwargs)
 
 
-def log_info(s: str) -> None:
-    _the_logging_context.write(s)
+logging.setLoggerClass(ModelLogger)
 
 
-def log_error(e: str) -> None:
-    _the_logging_context.print_error(e)
-    _the_logging_context.increase_error_count()
+class ExcludeStatusFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno != STATUS_LEVEL_NUM
+
+
+class OnlyStatusFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno == 25
 
 
 T = TypeVar("T")
 
 
-@overload
-def progress_bar(maybe_iterable: Iterable[T], *args: Any, **kwargs: Any) -> tqdm.tqdm[T]: ...  # noqa: ANN401
+class BarHandle:
+    def __init__(self, progress: Progress, task_id: TaskID) -> None:
+        self._progress = progress
+        self._task_id = task_id
+
+    # Match Progress.advance exactly
+    def advance(self, advance: float = 1) -> None:
+        self._progress.advance(self._task_id, advance)
+
+    # Match Progress.update exactly — forward all kwargs through
+    def update(
+        self,
+        *,
+        total: float | None = None,
+        completed: float | None = None,
+        advance: float | None = None,
+        description: str | None = None,
+        visible: bool | None = None,
+        refresh: bool = False,
+        **fields: Any,  # noqa: ANN401
+    ) -> None:
+        self._progress.update(
+            self._task_id,
+            total=total,
+            completed=completed,
+            advance=advance,
+            description=description,
+            visible=visible,
+            refresh=refresh,
+            **fields,
+        )
+
+    def track(
+        self,
+        sequence: Iterable[T],
+        *,
+        total: float | None = None,
+        completed: int = 0,
+        description: str = "",
+        update_period: float = 0.1,
+    ) -> Iterable[T]:
+        return self._progress.track(
+            sequence,
+            task_id=self._task_id,
+            description=description,
+            total=total,
+            completed=completed,
+            update_period=update_period,
+        )
 
 
-@overload
-def progress_bar(maybe_iterable: None = None, *args: Any, **kwargs: Any) -> tqdm.tqdm[object]: ...  # noqa: ANN401
+class OptionalColumn(ProgressColumn):
+    def __init__(self, condition: Callable[[Task], bool], real_col: ProgressColumn) -> None:
+        super().__init__()
+        self._real_col = real_col
+        self._condition = condition
+
+    def render(self, task: Task) -> console.RenderableType:
+        if not self._condition(task):
+            return ""
+        return self._real_col.render(task)
 
 
-def progress_bar(maybe_iterable: Iterable[T] | None = None, *args: Any, **kwargs: Any) -> tqdm.tqdm[T]:
-    tqdm_arguments: dict[str, Any] = {
-        "file": _the_logging_context,
-        "ascii": False,
-    }
+class StatusReporter:
+    class _LoggingHandler(logging.Handler):
+        def __init__(self, reporter: StatusReporter, model_name: str) -> None:
+            super().__init__()
+            self.reporter = reporter
+            self.model_name = model_name
 
-    try:
-        tqdm_arguments["ncols"] = os.get_terminal_size().columns - len(_the_logging_context.prefix)
-    except OSError:
-        # ncols is not available in CI or certain environments
-        tqdm_arguments["ncols"] = None
+        def emit(self, record: logging.LogRecord) -> None:
+            self.reporter.status_update(self.model_name, record.msg)
 
-    # This avoids any conflicts, and gives kwargs precedence
-    real_kwargs = {**tqdm_arguments, **kwargs}
+    def __init__(self) -> None:
+        self.active_status_bars: dict[str, TaskID] = {}
+        self.progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold]{task.description}[/]"),
+            TextColumn("[yellow]{task.fields[status]}[/]"),
+            OptionalColumn(lambda t: t.total is not None, BarColumn()),
+            OptionalColumn(lambda t: t.fields.get("m_of_n", False), MofNCompleteColumn()),
+            OptionalColumn(lambda t: t.total is not None, TextColumn("{task.percentage:>3.0f}%")),
+        )
 
-    if maybe_iterable is not None:
-        return tqdm.tqdm(maybe_iterable, *args, **real_kwargs)
-    else:
-        return tqdm.tqdm(*args, **real_kwargs)
+    def __enter__(self) -> StatusReporter:
+        self.progress.start()
+        return self
 
+    def __exit__(self, exc_type: type | None, exc_value: Exception | None, traceback: TracebackType | None) -> None:
+        self.progress.stop()
 
-def set_prefix(s: str) -> None:
-    _the_logging_context.set_prefix(s)
+    def start_model(self, model_name: str) -> None:
+        task_id = self.progress.add_task(f"{model_name}: ", status="Test Generation", total=None)
+        self.active_status_bars[model_name] = task_id
+        model_logger = logging.getLogger(model_name)
+
+        if isinstance(model_logger, ModelLogger):
+            model_logger.status_reporter = self
+
+        model_logger.handlers = []
+        model_logger.propagate = False
+
+        # Handle Status Updates
+        handler = self._LoggingHandler(self, model_name)
+        handler.addFilter(OnlyStatusFilter())
+        model_logger.addHandler(handler)
+
+        # Handle Other Updates
+        general_handler = RichHandler()
+        general_handler.addFilter(ExcludeStatusFilter())
+        model_logger.addHandler(general_handler)
+
+    def stop_model(self, model_name: str) -> None:
+        self.progress.remove_task(self.active_status_bars[model_name])
+        self.active_status_bars.pop(model_name)
+
+    def status_update(self, model_name: str, status_message: str) -> None:
+        task = self.active_status_bars[model_name]
+        self.progress.update(task, status=status_message)
+
+    @contextmanager
+    def progress_bar(
+        self, model_name: str, status: str | None = None, *, total: float | None = 100, show_m_of_n: bool = False
+    ) -> Generator[BarHandle, None, None]:
+        task_id = self.active_status_bars[model_name]
+
+        if status is not None:
+            self.progress.update(task_id, total=total, completed=0, status=status, m_of_n=show_m_of_n)
+        else:
+            self.progress.update(task_id, total=total, completed=0, m_of_n=show_m_of_n)
+
+        try:
+            yield BarHandle(self.progress, task_id)
+        finally:
+            self.progress.update(task_id, total=None, completed=0, m_of_n=False)

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -40,7 +40,7 @@ class ModelLogger(logging.Logger):
 
     @contextmanager
     def progress_bar(
-        self, model_name: str, status: str | None = None, *, total: float | None = 100, show_m_of_n: bool = False
+        self, status: str | None = None, *, total: float | None = 100, show_m_of_n: bool = False
     ) -> Generator[BarHandle, None, None]:
         handle = BarHandle(self.msg_queue, self.task_id)
 
@@ -93,17 +93,6 @@ class BarHandle:
         refresh: bool = False,
         **fields: Any,  # noqa: ANN401
     ) -> None:
-        # self._progress.update(
-        #     self._task_id,
-        #     total=total,
-        #     completed=completed,
-        #     advance=advance,
-        #     description=description,
-        #     visible=visible,
-        #     refresh=refresh,
-        #     **fields,
-        # )
-
         self._queue.put(
             {
                 "action": "update",
@@ -128,15 +117,6 @@ class BarHandle:
         completed: int = 0,
         update_period: float = 0.1,
     ) -> Iterable[T]:
-        # return self._progress.track(
-        #     sequence,
-        #     task_id=self._task_id,
-        #     description=description,
-        #     total=total,
-        #     completed=completed,
-        #     update_period=update_period,
-        # )
-
         if total is None and isinstance(sequence, Sized):
             total = len(sequence)
 

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -72,7 +72,7 @@ def progress_bar(maybe_iterable: Iterable[T] | None = None, *args: Any, **kwargs
     }
 
     try:
-        tqdm_arguments["ncols"] = (os.get_terminal_size().columns - len(_the_logging_context.prefix),)
+        tqdm_arguments["ncols"] = os.get_terminal_size().columns - len(_the_logging_context.prefix)
     except OSError:
         # ncols is not available in CI or certain environments
         tqdm_arguments["ncols"] = None

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -155,8 +155,6 @@ class LoggingHandler(logging.Handler):
 
 
 class AsyncLoggingHandler(logging.handlers.QueueListener):
-    _SENTINEL = None
-
     def __init__(self, reporter: StatusReporter, listen_to: Queue[Any], *handlers: logging.Handler) -> None:
         super().__init__(listen_to, *handlers)
 
@@ -184,9 +182,25 @@ class AsyncLoggingHandler(logging.handlers.QueueListener):
         else:
             self.handle_progress_update(record)
 
-        # Unfortunately, we have to do it this way because otherwise rich will data race itself
-        # here we ensure that refreshes happen in only one thread
-        self.reporter.progress.refresh()
+
+class ProgressAwareLogHandler(logging.Handler):
+    def __init__(self, progress: Progress) -> None:
+        super().__init__()
+        self.progress = progress
+        # We use the rich handler as a formatter
+        self.rich_handler = RichHandler(show_time=True, markup=True, console=progress.console)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = self.rich_handler.render_message(record, self.rich_handler.format(record))
+            renderable = self.rich_handler.render(
+                record=record,
+                traceback=None,
+                message_renderable=message,
+            )
+            self.progress.log(renderable)
+        except Exception:
+            self.handleError(record)
 
 
 class StatusReporter:
@@ -199,21 +213,20 @@ class StatusReporter:
             OptionalColumn(lambda t: t.total is not None, BarColumn()),
             OptionalColumn(lambda t: t.fields.get("m_of_n", False), MofNCompleteColumn()),
             OptionalColumn(lambda t: t.total is not None, TextColumn("{task.percentage:>3.0f}%")),
-            auto_refresh=False,
         )
 
         self.manager = multiprocessing.Manager()
-
         self.logging_queue = self.manager.Queue()
 
         # This is the actual handler that prints to console
-        self.rich_handler = RichHandler(show_time=True, markup=True, console=self.progress.console)
+        self.rich_handler = ProgressAwareLogHandler(self.progress)
         self.queue_listener = AsyncLoggingHandler(self, self.logging_queue, self.rich_handler)
         logging.getLogger().addHandler(logging.handlers.QueueHandler(self.logging_queue))
 
     def __enter__(self) -> StatusReporter:
         self.progress.start()
         self.queue_listener.start()
+
         return self
 
     def __exit__(self, exc_type: type | None, exc_value: Exception | None, traceback: TracebackType | None) -> None:

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import logging.handlers
 import multiprocessing
-import threading
 import time
 from collections.abc import Generator, Iterable, Sized
 from contextlib import contextmanager
@@ -175,40 +174,39 @@ class LoggingHandler(logging.Handler):
         self.reporter.status_update(self.model_name, record.msg)
 
 
-class AsyncLoggingHandler:
+class AsyncLoggingHandler(logging.handlers.QueueListener):
     _SENTINEL = None
 
-    def __init__(self, reporter: StatusReporter, listen_to: Queue[Any]) -> None:
+    def __init__(self, reporter: StatusReporter, listen_to: Queue[Any], *handlers: logging.Handler) -> None:
+        super().__init__(listen_to, *handlers)
+
         self.reporter = reporter
-        self.monitor_thread: threading.Thread | None = None
-        self.listen_to = listen_to
 
-    def start(self) -> None:
-        self.monitor_thread = threading.Thread(target=self.monitor_fn, daemon=True)
-        self.monitor_thread.start()
+    def handle_progress_update(self, record: dict[Any, Any]) -> None:
+        try:
+            action = record["action"]
+            if action == "update":
+                self.reporter.progress.update(*record["args"], **record["kwargs"])
+            elif action == "advance":
+                self.reporter.progress.advance(*record["args"], **record["kwargs"])
+            elif action == "remove_task":
+                model_name = record["args"][0]
+                self.reporter.progress.remove_task(self.reporter.active_status_bars[model_name])
+                self.reporter.active_status_bars.pop(model_name)
+            else:
+                logging.info(f"Failed to Log {record}")
+        except Exception as e:
+            logging.info(f"Failed to Log {record}", exc_info=e)
 
-    def stop(self) -> None:
-        self.listen_to.put(self._SENTINEL)
-        if self.monitor_thread:
-            self.monitor_thread.join()
-            self.monitor_thread = None
+    def handle(self, record: logging.LogRecord | dict[Any, Any]) -> None:
+        if isinstance(record, logging.LogRecord):
+            super().handle(record)
+        else:
+            self.handle_progress_update(record)
 
-    def monitor_fn(self) -> None:
-        while True:
-            record = self.listen_to.get(block=True)
-            if record is self._SENTINEL:
-                break
-
-            try:
-                action = record["action"]
-                if action == "update":
-                    self.reporter.progress.update(*record["args"], **record["kwargs"])
-                elif action == "advance":
-                    self.reporter.progress.advance(*record["args"], **record["kwargs"])
-                else:
-                    logging.info(f"Failed to Log {record}")
-            except Exception as e:
-                logging.info(f"Failed to Log {record}", exc_info=e)
+        # Unfortunately, we have to do it this way because otherwise rich will data race itself
+        # here we ensure that refreshes happen in only one thread
+        self.reporter.progress.refresh()
 
 
 class StatusReporter:
@@ -221,30 +219,25 @@ class StatusReporter:
             OptionalColumn(lambda t: t.total is not None, BarColumn()),
             OptionalColumn(lambda t: t.fields.get("m_of_n", False), MofNCompleteColumn()),
             OptionalColumn(lambda t: t.total is not None, TextColumn("{task.percentage:>3.0f}%")),
+            auto_refresh=False,
         )
 
         self.manager = multiprocessing.Manager()
 
-        self.progress_queue = self.manager.Queue()
         self.logging_queue = self.manager.Queue()
 
         # This is the actual handler that prints to console
-        self.rich_handler = RichHandler(show_time=True, markup=True)
-        self.queue_listener = logging.handlers.QueueListener(self.logging_queue, self.rich_handler)
-        logging.getLogger().addHandler(self.rich_handler)
-        logging.getLogger().propagate = False
-
-        self.progress_listener = AsyncLoggingHandler(self, self.progress_queue)
+        self.rich_handler = RichHandler(show_time=True, markup=True, console=self.progress.console)
+        self.queue_listener = AsyncLoggingHandler(self, self.logging_queue, self.rich_handler)
+        logging.getLogger().addHandler(logging.handlers.QueueHandler(self.logging_queue))
 
     def __enter__(self) -> StatusReporter:
         self.progress.start()
         self.queue_listener.start()
-        self.progress_listener.start()
         return self
 
     def __exit__(self, exc_type: type | None, exc_value: Exception | None, traceback: TracebackType | None) -> None:
         self.queue_listener.stop()
-        self.progress_listener.stop()
         self.progress.stop()
 
     def start_model(self, model_name: str) -> TaskID:
@@ -253,8 +246,9 @@ class StatusReporter:
         return task_id
 
     def stop_model(self, model_name: str) -> None:
-        self.progress.remove_task(self.active_status_bars[model_name])
-        self.active_status_bars.pop(model_name)
+        # This can be a race condition, if there is logging still in the queue
+        # so we must enqueue the destruction
+        self.logging_queue.put({"action": "remove_task", "args": [model_name], "kwargs": {}})
 
     def status_update(self, model_name: str, status_message: str) -> None:
         task = self.active_status_bars[model_name]

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+import os
+from collections.abc import Iterable
+from typing import Any, TypeVar, overload
+
+import tqdm
+
+
+class LoggingContext(io.TextIOBase):
+    def __init__(self, prefix: str) -> None:
+        super().__init__()
+        self.prefix = prefix
+        self.error_count = 0
+        self.last_print = ""
+
+        self.write("")
+
+    def write(self, s: str) -> int:
+        processed_string = s.strip("\r").replace("\n", "\r\033[K")
+        print("\033[K" + self.prefix + processed_string, end="\r")
+        self.last_print = s
+
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return True
+
+    def increase_error_count(self) -> None:
+        self.error_count += 1
+
+    def set_prefix(self, prefix: str) -> None:
+        self.prefix = prefix
+        self.write("")
+
+    def print_error(self, error: str) -> None:
+        print(self.prefix + error)
+        self.write(self.last_print)
+
+
+_the_logging_context = LoggingContext("")
+
+
+def log_info(s: str) -> None:
+    _the_logging_context.write(s)
+
+
+def log_error(e: str) -> None:
+    _the_logging_context.print_error(e)
+    _the_logging_context.increase_error_count()
+
+
+T = TypeVar("T")
+
+
+@overload
+def progress_bar(maybe_iterable: Iterable[T], *args: Any, **kwargs: Any) -> tqdm.tqdm[T]: ...  # noqa: ANN401
+
+
+@overload
+def progress_bar(maybe_iterable: None = None, *args: Any, **kwargs: Any) -> tqdm.tqdm[object]: ...  # noqa: ANN401
+
+
+def progress_bar(maybe_iterable: Iterable[T] | None = None, *args: Any, **kwargs: Any) -> tqdm.tqdm[T]:
+    tqdm_arguments: dict[str, Any] = {
+        "file": _the_logging_context,
+        "ascii": False,
+    }
+
+    try:
+        tqdm_arguments["ncols"] = (os.get_terminal_size().columns - len(_the_logging_context.prefix),)
+    except OSError:
+        # ncols is not available in CI or certain environments
+        tqdm_arguments["ncols"] = None
+
+    # This avoids any conflicts, and gives kwargs precedence
+    real_kwargs = {**tqdm_arguments, **kwargs}
+
+    if maybe_iterable is not None:
+        return tqdm.tqdm(maybe_iterable, *args, **real_kwargs)
+    else:
+        return tqdm.tqdm(*args, **real_kwargs)
+
+
+def set_prefix(s: str) -> None:
+    _the_logging_context.set_prefix(s)

--- a/src/cover_float/common/util.py
+++ b/src/cover_float/common/util.py
@@ -1,4 +1,8 @@
+import concurrent.futures
 from dataclasses import dataclass
+from typing import Callable, TypeVar
+
+from typing_extensions import ParamSpec
 
 import cover_float.common.constants as constants
 import cover_float.reference as reference
@@ -194,3 +198,20 @@ def extract_rounding_info(cover_vector: str) -> dict[str, int]:
         "Guard": int(guard),
         "Sticky": 1 if any(x == "1" for x in sticky) else 0,
     }
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class SingleThreadedExecutor(concurrent.futures.Executor):
+    def submit(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> concurrent.futures.Future[T]:
+        future: concurrent.futures.Future[T] = concurrent.futures.Future()
+
+        try:
+            result = fn(*args, **kwargs)
+            future.set_result(result)
+        except Exception as e:
+            future.set_exception(e)
+
+        return future

--- a/src/cover_float/scripts/parse_testvectors.py
+++ b/src/cover_float/scripts/parse_testvectors.py
@@ -14,6 +14,7 @@ Currently supports
 """
 
 import logging
+import time
 from pathlib import Path
 from typing import Any, Optional, cast
 
@@ -286,7 +287,10 @@ def auto_parse(model_name: str, output_dir: str) -> None:
     with input_path.open("r") as infile, output_path.open("w") as outfile:
         input_size = input_path.stat().st_size
 
-        with logger.status_reporter.progress_bar(model_name, "Post Processing", total=input_size) as bar:
+        last_update = time.monotonic()
+        update_size = 0
+
+        with logger.progress_bar(model_name, "Post Processing", total=input_size) as bar:
             for line in infile:
                 parsed = parse_test_vector(line)
 
@@ -294,6 +298,11 @@ def auto_parse(model_name: str, output_dir: str) -> None:
                     outfile.write(format_output(parsed) + "\n")
                     count += 1
 
-                bar.advance(len(line))
+                now = time.monotonic()
+                update_size += len(line)
+                if now - last_update >= 0.1:
+                    bar.advance(update_size)
+                    last_update = now
+                    update_size = 0
 
     logger.info(f"Parsed {count} {model_name} vectors to {output_path}")

--- a/src/cover_float/scripts/parse_testvectors.py
+++ b/src/cover_float/scripts/parse_testvectors.py
@@ -290,7 +290,7 @@ def auto_parse(model_name: str, output_dir: str) -> None:
         last_update = time.monotonic()
         update_size = 0
 
-        with logger.progress_bar(model_name, "Post Processing", total=input_size) as bar:
+        with logger.progress_bar("Post Processing", total=input_size) as bar:
             for line in infile:
                 parsed = parse_test_vector(line)
 

--- a/src/cover_float/scripts/parse_testvectors.py
+++ b/src/cover_float/scripts/parse_testvectors.py
@@ -13,10 +13,11 @@ Currently supports
 - Flags: 'x' if a flag is raised and '' if none
 """
 
+import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
-from cover_float.common.log import progress_bar
+import cover_float.common.log as log
 
 FMT_SPECS: dict[str, dict[str, Any]] = {
     "00": {"name": "f16", "type": "float", "exp_bits": 5, "man_bits": 10, "bias": 15, "total_bits": 16},
@@ -274,6 +275,8 @@ def format_output(parsed: dict[str, Any]) -> str:
 
 
 def auto_parse(model_name: str, output_dir: str) -> None:
+    logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger(model_name))
+
     input_path = Path(output_dir) / "testvectors" / f"{model_name}_tv.txt"
     output_path = Path(output_dir) / "readable" / f"{model_name}_parsed.txt"
 
@@ -283,7 +286,7 @@ def auto_parse(model_name: str, output_dir: str) -> None:
     with input_path.open("r") as infile, output_path.open("w") as outfile:
         input_size = input_path.stat().st_size
 
-        with progress_bar(total=input_size, bar_format="{l_bar}{bar}| [{elapsed}/{remaining}]") as bar:
+        with logger.status_reporter.progress_bar(model_name, "Post Processing", total=input_size) as bar:
             for line in infile:
                 parsed = parse_test_vector(line)
 
@@ -291,6 +294,6 @@ def auto_parse(model_name: str, output_dir: str) -> None:
                     outfile.write(format_output(parsed) + "\n")
                     count += 1
 
-                bar.update(len(line))
+                bar.advance(len(line))
 
-    print(f"Parsed {count} {model_name} vectors to {output_path}")
+    logger.info(f"Parsed {count} {model_name} vectors to {output_path}")

--- a/src/cover_float/scripts/parse_testvectors.py
+++ b/src/cover_float/scripts/parse_testvectors.py
@@ -13,7 +13,10 @@ Currently supports
 - Flags: 'x' if a flag is raised and '' if none
 """
 
+from pathlib import Path
 from typing import Any, Optional
+
+from cover_float.common.log import progress_bar
 
 FMT_SPECS: dict[str, dict[str, Any]] = {
     "00": {"name": "f16", "type": "float", "exp_bits": 5, "man_bits": 10, "bias": 15, "total_bits": 16},
@@ -268,3 +271,26 @@ def format_output(parsed: dict[str, Any]) -> str:
         base = f"{op} {rnd} {a} {b}"
 
     return f"{base} -> {parsed['result']} ({parsed['res_fmt_name']}){flags}"
+
+
+def auto_parse(model_name: str, output_dir: str) -> None:
+    input_path = Path(output_dir) / "testvectors" / f"{model_name}_tv.txt"
+    output_path = Path(output_dir) / "readable" / f"{model_name}_parsed.txt"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    with input_path.open("r") as infile, output_path.open("w") as outfile:
+        input_size = input_path.stat().st_size
+
+        with progress_bar(total=input_size, bar_format="{l_bar}{bar}| [{elapsed}/{remaining}]") as bar:
+            for line in infile:
+                parsed = parse_test_vector(line)
+
+                if parsed:
+                    outfile.write(format_output(parsed) + "\n")
+                    count += 1
+
+                bar.update(len(line))
+
+    print(f"Parsed {count} {model_name} vectors to {output_path}")

--- a/src/cover_float/testgen/B1.py
+++ b/src/cover_float/testgen/B1.py
@@ -1,9 +1,12 @@
-from typing import TextIO
+import logging
+from typing import TextIO, cast
 
 import cover_float.common.constants as const
-from cover_float.common.log import log_info
+import cover_float.common.log as log
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
 
 SRC1_OPS = [const.OP_SQRT, const.OP_CLASS]
 
@@ -278,7 +281,7 @@ def write1SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     print("// 1 source operations, all basic type input combinations", file=test_f)
     # print("//", file=f)
     for op in SRC1_OPS:
-        log_info(f"OP IS: {op}")
+        logger.status(f"OP IS: {op}")
         # print(f"FMT IS: {fmt}")
         for val in BASIC_TYPES[fmt]:
             run_and_store_test_vector(
@@ -294,7 +297,7 @@ def writeCvtTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     print("// 1 source convert operations, all basic type input and result format combinations", file=test_f)
     # print("//", file=f)
     for op in CVT_OPS:
-        log_info(f"OP IS: {op}")
+        logger.status(f"OP IS: {op}")
         # print(f"FMT IS: {fmt}")
         fmts = const.FLOAT_FMTS if op == const.OP_CFF else const.INT_FMTS
         for resultFmt in fmts:
@@ -311,7 +314,7 @@ def write2SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
     print("// 2 source operations, all basic type input combinations", file=test_f)
     for op in SRC2_OPS:
-        log_info(f"OP IS: {op}")
+        logger.status(f"OP IS: {op}")
         for val1 in BASIC_TYPES[fmt]:
             for val2 in BASIC_TYPES[fmt]:
                 run_and_store_test_vector(
@@ -325,7 +328,7 @@ def write3SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
     print("// 3 source operations, all basic type input combinations", file=test_f)
     for op in SRC3_OPS:
-        log_info(f"OP IS: {op}")
+        logger.status(f"OP IS: {op}")
         for val1 in BASIC_TYPES[fmt]:
             for val2 in BASIC_TYPES[fmt]:
                 for val3 in BASIC_TYPES[fmt]:

--- a/src/cover_float/testgen/B1.py
+++ b/src/cover_float/testgen/B1.py
@@ -1,8 +1,9 @@
-from pathlib import Path
 from typing import TextIO
 
 import cover_float.common.constants as const
+from cover_float.common.log import log_info
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 SRC1_OPS = [const.OP_SQRT, const.OP_CLASS]
 
@@ -277,7 +278,7 @@ def write1SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     print("// 1 source operations, all basic type input combinations", file=test_f)
     # print("//", file=f)
     for op in SRC1_OPS:
-        print(f"OP IS: {op}")
+        log_info(f"OP IS: {op}")
         # print(f"FMT IS: {fmt}")
         for val in BASIC_TYPES[fmt]:
             run_and_store_test_vector(
@@ -293,7 +294,7 @@ def writeCvtTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     print("// 1 source convert operations, all basic type input and result format combinations", file=test_f)
     # print("//", file=f)
     for op in CVT_OPS:
-        print(f"OP IS: {op}")
+        log_info(f"OP IS: {op}")
         # print(f"FMT IS: {fmt}")
         fmts = const.FLOAT_FMTS if op == const.OP_CFF else const.INT_FMTS
         for resultFmt in fmts:
@@ -310,7 +311,7 @@ def write2SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
     print("// 2 source operations, all basic type input combinations", file=test_f)
     for op in SRC2_OPS:
-        print(f"OP IS: {op}")
+        log_info(f"OP IS: {op}")
         for val1 in BASIC_TYPES[fmt]:
             for val2 in BASIC_TYPES[fmt]:
                 run_and_store_test_vector(
@@ -324,7 +325,7 @@ def write3SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
     print("// 3 source operations, all basic type input combinations", file=test_f)
     for op in SRC3_OPS:
-        print(f"OP IS: {op}")
+        log_info(f"OP IS: {op}")
         for val1 in BASIC_TYPES[fmt]:
             for val2 in BASIC_TYPES[fmt]:
                 for val3 in BASIC_TYPES[fmt]:
@@ -333,21 +334,15 @@ def write3SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     )
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B1_tv.txt").open("w") as test_vectors,
-        Path("./tests/covervectors/B1_cv.txt").open("w") as cover_vectors,
-    ):
-        for fmt in const.FLOAT_FMTS:
-            write1SrcTests(test_vectors, cover_vectors, fmt)
-            write2SrcTests(test_vectors, cover_vectors, fmt)
-            write3SrcTests(test_vectors, cover_vectors, fmt)
-            writeCvtTests(test_vectors, cover_vectors, fmt)
-            # writeResultTests(f, fmt)
+@register_model("B1")
+def main(test_vectors: TextIO, cover_vectors: TextIO) -> None:
+    for fmt in const.FLOAT_FMTS:
+        write1SrcTests(test_vectors, cover_vectors, fmt)
+        write2SrcTests(test_vectors, cover_vectors, fmt)
+        write3SrcTests(test_vectors, cover_vectors, fmt)
+        writeCvtTests(test_vectors, cover_vectors, fmt)
+        # writeResultTests(f, fmt)
 
-
-if __name__ == "__main__":
-    main()
 
 """
 

--- a/src/cover_float/testgen/B10.py
+++ b/src/cover_float/testgen/B10.py
@@ -3,7 +3,6 @@
 # This model tests every possible value for a shift between the input operands
 
 import random
-from pathlib import Path
 from random import seed
 from typing import TextIO
 
@@ -18,6 +17,7 @@ from cover_float.common.constants import (
 )
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 
 def decimalComponentsToHex(fmt: str, biased_exp: int) -> str:
@@ -103,16 +103,9 @@ def outerTest(isTestOne: bool, test_f: TextIO, cover_f: TextIO, op: str) -> None
             )
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B10_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B10_cv.txt").open("w") as cover_f,
-    ):
-        for op in [OP_ADD, OP_SUB]:
-            outerTest(True, test_f, cover_f, op)  # Test #1
-            innerTest(test_f, cover_f, op)  # Test #2
-            outerTest(False, test_f, cover_f, op)  # Test #3
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B10")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for op in [OP_ADD, OP_SUB]:
+        outerTest(True, test_f, cover_f, op)  # Test #1
+        innerTest(test_f, cover_f, op)  # Test #2
+        outerTest(False, test_f, cover_f, op)  # Test #3

--- a/src/cover_float/testgen/B11.py
+++ b/src/cover_float/testgen/B11.py
@@ -8,16 +8,19 @@
 # the interesting shift ranges, so short and long shifts: [-3, 3], [nf, nf-3], and [-nf, -nf+3]
 
 import itertools
+import logging
 import random
 from pathlib import Path
-from typing import TextIO
+from typing import TextIO, cast
 
 import cover_float.common.constants as constants
-from cover_float.common.log import log_info
+import cover_float.common.log as log
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.B9 import B9SignificandGenerator
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B11"))
 
 B11_OPS = [constants.OP_ADD, constants.OP_SUB]
 
@@ -101,7 +104,7 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
         seed = reproducible_hash(fmt + "b11")
         random.seed(seed)
 
-        log_info(f"Generating {fmt} Sigs & Shifts")
+        logger.status(f"Generating {fmt} Sigs & Shifts")
         bins_path = Path(
             "coverage",
             "covergroups",
@@ -116,6 +119,6 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
             sigs = [int(sig, 2) for sig in sig_gen.generate(generated_coverage)]
             interesting_shifts = interesting_shift_ranges(2, 2, fmt)
 
-            log_info(f"Generating {fmt} Tests")
+            logger.status(f"Generating {fmt} Tests")
             interesting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)
             uninteresting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B11.py
+++ b/src/cover_float/testgen/B11.py
@@ -13,9 +13,11 @@ from pathlib import Path
 from typing import TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.log import log_info
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.B9 import B9SignificandGenerator
+from cover_float.testgen.model import register_model
 
 B11_OPS = [constants.OP_ADD, constants.OP_SUB]
 
@@ -93,34 +95,27 @@ def uninteresting_tests(
             run_and_store_test_vector(tv, test_f, cover_f)
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B11_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B11_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            seed = reproducible_hash(fmt + "b11")
-            random.seed(seed)
+@register_model("B11")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        seed = reproducible_hash(fmt + "b11")
+        random.seed(seed)
 
-            print(f"Generating {fmt} Sigs & Shifts")
-            bins_path = Path(
-                "coverage",
-                "covergroups",
-                "bins_templates",
-                "generated",
-                f"B11_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh",
-            )
-            bins_path.parent.mkdir(parents=True, exist_ok=True)
+        log_info(f"Generating {fmt} Sigs & Shifts")
+        bins_path = Path(
+            "coverage",
+            "covergroups",
+            "bins_templates",
+            "generated",
+            f"B11_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh",
+        )
+        bins_path.parent.mkdir(parents=True, exist_ok=True)
 
-            with bins_path.open("w") as generated_coverage:
-                sig_gen = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], "b11" + fmt)
-                sigs = [int(sig, 2) for sig in sig_gen.generate(generated_coverage)]
-                interesting_shifts = interesting_shift_ranges(2, 2, fmt)
+        with bins_path.open("w") as generated_coverage:
+            sig_gen = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], "b11" + fmt)
+            sigs = [int(sig, 2) for sig in sig_gen.generate(generated_coverage)]
+            interesting_shifts = interesting_shift_ranges(2, 2, fmt)
 
-                print(f"Generating {fmt} Tests")
-                interesting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)
-                uninteresting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+            log_info(f"Generating {fmt} Tests")
+            interesting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)
+            uninteresting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B12.py
+++ b/src/cover_float/testgen/B12.py
@@ -7,7 +7,6 @@ Last Edited:    March 4, 2026
 
 # TODO: For future: implement logic to get different a and b exponents in regular cases
 import random
-from pathlib import Path
 from random import seed
 from typing import TextIO
 
@@ -22,6 +21,7 @@ from cover_float.common.constants import (
 )
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 
 def decimalComponentsToHex(fmt: str, sign: int, biased_exp: int, mantissa: int) -> str:
@@ -164,17 +164,10 @@ def CancellationTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
         makeTestVectors(fmt, d, "sub", test_f, cover_f)
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B12_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B12_cv.txt").open("w") as cover_f,
-    ):
-        test_f.write("// Cancellation tests\n")
-        test_f.write("// Operations: ADD, SUB\n")
+@register_model("B12")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    test_f.write("// Cancellation tests\n")
+    test_f.write("// Operations: ADD, SUB\n")
 
-        for fmt in FLOAT_FMTS:
-            CancellationTests(test_f, cover_f, fmt)
-
-
-if __name__ == "__main__":
-    main()
+    for fmt in FLOAT_FMTS:
+        CancellationTests(test_f, cover_f, fmt)

--- a/src/cover_float/testgen/B13.py
+++ b/src/cover_float/testgen/B13.py
@@ -6,7 +6,6 @@ Last Edited:    March 30, 2026
 """
 
 import random
-from pathlib import Path
 from random import seed
 from typing import TextIO
 
@@ -20,6 +19,7 @@ from cover_float.common.constants import (
 )
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 
 # TODO: Investigate d = -1 case.
@@ -181,17 +181,10 @@ def SubnormCancellationTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 makeTestVectors(fmt, d, leading_zeros, "sub", test_f, cover_f)
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B13_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B13_cv.txt").open("w") as cover_f,
-    ):
-        test_f.write("// B13 Cancellation + Subnormal Tests\n")
-        test_f.write("// ADD, SUB\n")
+@register_model("B13")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    test_f.write("// B13 Cancellation + Subnormal Tests\n")
+    test_f.write("// ADD, SUB\n")
 
-        for fmt in FLOAT_FMTS:
-            SubnormCancellationTests(test_f, cover_f, fmt)
-
-
-if __name__ == "__main__":
-    main()
+    for fmt in FLOAT_FMTS:
+        SubnormCancellationTests(test_f, cover_f, fmt)

--- a/src/cover_float/testgen/B14.py
+++ b/src/cover_float/testgen/B14.py
@@ -12,15 +12,18 @@
 # 3.A value larger than (p + 1)
 
 
+import logging
 import random
 from random import seed
-from typing import TextIO
+from typing import TextIO, cast
 
 import cover_float.common.constants as const
-from cover_float.common.log import progress_bar
+import cover_float.common.log as log
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B14"))
 
 OPS = [const.OP_FMADD, const.OP_FMSUB, const.OP_FNMADD, const.OP_FNMSUB]
 
@@ -57,54 +60,57 @@ def generate_b14_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     start_shift = -limit
     end_shift = limit
 
-    for target_shift in progress_bar(range(start_shift, end_shift + 1), desc=f"{fmt} Shifts"):
-        for op in OPS:
-            hashval = reproducible_hash(op + fmt + "b14")  # Unique hash for (op, fmt) seed
-            seed(hashval)  # Seed the random generator for reproducibility
-            # Randomize & generate 15 variations per shift
-            for _ in range(15):
-                ##Part 1: Randomize a and b exponents (and make sure their product is valid)
-                # a:
-                # safe margin defined to keep 'a' somewhat central to avoid immediate overflows
-                safe_margin = int(max_exp / 4)
-                exp_a = random.randint(min_exp + safe_margin, max_exp - safe_margin)
-                # b:
-                low_bound = max(min_exp, bias - 50)
-                high_bound = min(max_exp, bias + 50)
-                # Pick 'b' near the bias (so product exponent is close to exp_a) or random. This is simplified;
-                # we might want more range here.
-                exp_b = random.randint(low_bound, high_bound)
+    with logger.status_reporter.progress_bar("B14", f"{fmt} Shifts") as pbar:
+        for target_shift in pbar.track(range(start_shift, end_shift + 1)):
+            for op in OPS:
+                hashval = reproducible_hash(op + fmt + "b14")  # Unique hash for (op, fmt) seed
+                seed(hashval)  # Seed the random generator for reproducibility
+                # Randomize & generate 15 variations per shift
+                for _ in range(15):
+                    ##Part 1: Randomize a and b exponents (and make sure their product is valid)
+                    # a:
+                    # safe margin defined to keep 'a' somewhat central to avoid immediate overflows
+                    safe_margin = int(max_exp / 4)
+                    exp_a = random.randint(min_exp + safe_margin, max_exp - safe_margin)
+                    # b:
+                    low_bound = max(min_exp, bias - 50)
+                    high_bound = min(max_exp, bias + 50)
+                    # Pick 'b' near the bias (so product exponent is close to exp_a) or random. This is simplified;
+                    # we might want more range here.
+                    exp_b = random.randint(low_bound, high_bound)
 
-                ##Part 2: Calculate the addends
-                # Calculate product exponent:Exp_Prod = Exp_A + Exp_B - Bias
-                exp_prod = exp_a + exp_b - bias
+                    ##Part 2: Calculate the addends
+                    # Calculate product exponent:Exp_Prod = Exp_A + Exp_B - Bias
+                    exp_prod = exp_a + exp_b - bias
 
-                # Calculate required Exp_C to hit the Target Shift: target_shift = Exp_C - Exp_Prod
-                exp_c = target_shift + exp_prod
+                    # Calculate required Exp_C to hit the Target Shift: target_shift = Exp_C - Exp_Prod
+                    exp_c = target_shift + exp_prod
 
-                # Quick validity check -> If the calculated exp_c is invalid (too big/small), skip this variation
-                if exp_c < min_exp or exp_c > max_exp:
-                    continue
+                    # Quick validity check -> If the calculated exp_c is invalid (too big/small), skip this variation
+                    if exp_c < min_exp or exp_c > max_exp:
+                        continue
 
-                ##Part 3: Generate mantissa componenets + Assemble >:3
-                # Create random signs (0 or 1)
-                sign_a = random.randint(0, 1)
-                sign_b = random.randint(0, 1)
-                sign_c = random.randint(0, 1)
+                    ##Part 3: Generate mantissa componenets + Assemble >:3
+                    # Create random signs (0 or 1)
+                    sign_a = random.randint(0, 1)
+                    sign_b = random.randint(0, 1)
+                    sign_c = random.randint(0, 1)
 
-                # Randomize mantissas -> Uses random bits to trigger different carry/rounding paths.
-                mant_a = random.getrandbits(const.MANTISSA_BITS[fmt])
-                mant_b = random.getrandbits(const.MANTISSA_BITS[fmt])
-                mant_c = random.getrandbits(const.MANTISSA_BITS[fmt])
+                    # Randomize mantissas -> Uses random bits to trigger different carry/rounding paths.
+                    mant_a = random.getrandbits(const.MANTISSA_BITS[fmt])
+                    mant_b = random.getrandbits(const.MANTISSA_BITS[fmt])
+                    mant_c = random.getrandbits(const.MANTISSA_BITS[fmt])
 
-                # Converts the components created above to hex
-                hex_a = decimalComponentsToHex(fmt, sign_a, exp_a, mant_a)
-                hex_b = decimalComponentsToHex(fmt, sign_b, exp_b, mant_b)
-                hex_c = decimalComponentsToHex(fmt, sign_c, exp_c, mant_c)
+                    # Converts the components created above to hex
+                    hex_a = decimalComponentsToHex(fmt, sign_a, exp_a, mant_a)
+                    hex_b = decimalComponentsToHex(fmt, sign_b, exp_b, mant_b)
+                    hex_c = decimalComponentsToHex(fmt, sign_c, exp_c, mant_c)
 
-                run_and_store_test_vector(
-                    f"{op}_{const.ROUND_NEAR_EVEN}_{hex_a}_{hex_b}_{hex_c}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f
-                )
+                    run_and_store_test_vector(
+                        f"{op}_{const.ROUND_NEAR_EVEN}_{hex_a}_{hex_b}_{hex_c}_{fmt}_{32 * '0'}_{fmt}_00",
+                        test_f,
+                        cover_f,
+                    )
 
 
 @register_model("B14")

--- a/src/cover_float/testgen/B14.py
+++ b/src/cover_float/testgen/B14.py
@@ -60,7 +60,7 @@ def generate_b14_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     start_shift = -limit
     end_shift = limit
 
-    with logger.status_reporter.progress_bar("B14", f"{fmt} Shifts") as pbar:
+    with logger.progress_bar("B14", f"{fmt} Shifts", show_m_of_n=True) as pbar:
         for target_shift in pbar.track(range(start_shift, end_shift + 1)):
             for op in OPS:
                 hashval = reproducible_hash(op + fmt + "b14")  # Unique hash for (op, fmt) seed

--- a/src/cover_float/testgen/B14.py
+++ b/src/cover_float/testgen/B14.py
@@ -13,13 +13,14 @@
 
 
 import random
-from pathlib import Path
 from random import seed
 from typing import TextIO
 
 import cover_float.common.constants as const
+from cover_float.common.log import progress_bar
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 OPS = [const.OP_FMADD, const.OP_FMSUB, const.OP_FNMADD, const.OP_FNMSUB]
 
@@ -56,7 +57,7 @@ def generate_b14_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     start_shift = -limit
     end_shift = limit
 
-    for target_shift in range(start_shift, end_shift + 1):
+    for target_shift in progress_bar(range(start_shift, end_shift + 1), desc=f"{fmt} Shifts"):
         for op in OPS:
             hashval = reproducible_hash(op + fmt + "b14")  # Unique hash for (op, fmt) seed
             seed(hashval)  # Seed the random generator for reproducibility
@@ -106,14 +107,7 @@ def generate_b14_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 )
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B14_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B14_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in const.FLOAT_FMTS:
-            generate_b14_tests(test_f, cover_f, fmt)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B14")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in const.FLOAT_FMTS:
+        generate_b14_tests(test_f, cover_f, fmt)

--- a/src/cover_float/testgen/B14.py
+++ b/src/cover_float/testgen/B14.py
@@ -60,7 +60,7 @@ def generate_b14_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
     start_shift = -limit
     end_shift = limit
 
-    with logger.progress_bar("B14", f"{fmt} Shifts", show_m_of_n=True) as pbar:
+    with logger.progress_bar(f"{fmt} Shifts", show_m_of_n=True) as pbar:
         for target_shift in pbar.track(range(start_shift, end_shift + 1)):
             for op in OPS:
                 hashval = reproducible_hash(op + fmt + "b14")  # Unique hash for (op, fmt) seed

--- a/src/cover_float/testgen/B15.py
+++ b/src/cover_float/testgen/B15.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.log import log_error, log_info
 from cover_float.common.util import (
     bezout_inverse,
     factors_to_bit_width,
@@ -16,6 +17,7 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.B9 import B9SignificandGenerator
+from cover_float.testgen.model import register_model
 
 if TYPE_CHECKING:
     # This block is seen by Pyright but ignored at runtime
@@ -39,9 +41,10 @@ class B15Significand:
 
 
 class B15SignificandGenerator:
-    def __init__(self, nf: int, seed: str) -> None:
+    def __init__(self, nf: int, fmt: str, seed: str) -> None:
         self.sigs: list[B15Significand] = []
         self.nf = nf
+        self.fmt = fmt
         self.seed = seed
 
     def checkerboards(self, patterns: Optional[list[tuple[int, int]]] = None) -> None:
@@ -380,7 +383,7 @@ class B15SignificandGenerator:
 
         hits = 0
         for attempt in range(10000):
-            print(f"hits: {hits}/10, attempts: {attempt}", end="\r")
+            log_info(f"Generating {self.fmt} Sparse Zeros: Generated: {hits}/10, Attempts: {attempt}")
             target = (1 << (2 * self.nf + 2)) - 1
             for _ in range(min(8, self.nf // 2)):
                 p2 = random.randint(1, 2 * self.nf)
@@ -397,7 +400,6 @@ class B15SignificandGenerator:
                 hits += 1
                 if hits == 10:
                     break
-        print("\x1b[2K", end="\r")
 
     @staticmethod
     def evenly_spaced_numbers(start: int, end: int, count: int) -> list[int]:
@@ -443,8 +445,10 @@ class B15SignificandGenerator:
 
             sig1_pattern = "10" * (teeth_length) + "1" * internal_ones_count + "01" * teeth_length
             if len(sig1_pattern) > self.nf + 1:
-                print(f"""Invalid Arrangement for Long Run of Ones, offset={offset}, run_length={run_length} \
-                      \n\t Generated Sig1: {sig1_pattern}, length={len(sig1_pattern)}""")
+                log_error(
+                    f"Invalid Arrangement for Long Run of Ones, offset={offset}, run_length={run_length} "
+                    f"Generated Sig1: {sig1_pattern}, length={len(sig1_pattern)}"
+                )
                 continue
 
             sig1_pattern += "0" * (self.nf + 1 - len(sig1_pattern))
@@ -509,7 +513,7 @@ class B15SignificandGenerator:
                         self.sigs.append(B15Significand(sig1, sig2, target))
                         break
                 else:
-                    print("Long Run Zeros Failed (factoring)")
+                    log_error("Long Run Zeros Failed (factoring)")
             elif run_length + offset - self.nf < 20:
                 # We can generally get away with the stochastic search here (limitation still exists for nf=112)
                 best = 2 * self.nf, 0, 0
@@ -547,7 +551,7 @@ class B15SignificandGenerator:
                         best = score, sig1, sig2
 
                 if best[0] != 0:
-                    print("Long Run Zeros Failed :(")
+                    log_error(f"Long Run Zeros Failed for {self.fmt}")
 
                 sig1 = bin(best[1])[3:]
                 sig2 = bin(best[2])[3:]
@@ -555,23 +559,23 @@ class B15SignificandGenerator:
                 self.sigs.append(B15Significand(sig1, sig2, res))
 
     def generate(self, file: TextIO) -> list[tuple[str, str]]:
-        print("\tChecker Boards")
+        log_info(f"Generating {self.fmt} Checker Boards")
         self.checkerboards()
-        print("\tTrailing Zeros")
+        log_info(f"Generating {self.fmt} Trailing Zeros")
         self.trailing_zeros()
-        print("\tTrailing Ones")
+        log_info(f"Generating {self.fmt} Trailing Ones")
         self.trailing_ones()
-        print("\tLeading Zeros")
+        log_info(f"Generating {self.fmt} Leading Zeros")
         self.leading_zeros()
-        print("\tLeading Ones")
+        log_info(f"Generating {self.fmt} Leading Ones")
         self.leading_ones()
-        print("\tSparse Ones")
+        log_info(f"Generating {self.fmt} Sparse Ones")
         self.sparse_ones()
-        print("\tSparse Zeros")
+        log_info(f"Generating {self.fmt} Sparse Zeros")
         self.sparse_zeros()
-        print("\tLong Runs of Ones")
+        log_info(f"Generating {self.fmt} Long Runs of Ones")
         self.long_run_ones()
-        print("\tLong Runs of Zeros")
+        log_info(f"Generating {self.fmt} Long Runs of Zeros")
         self.long_run_zeros()
 
         self.store_sigs(file)
@@ -703,34 +707,27 @@ def interesting_shift_ranges(low_shifts: int, shifts_from_edge: int, fmt: str) -
     return shifts
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B15_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B15_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            hashval = reproducible_hash(fmt + "b15")
-            random.seed(hashval)
+@register_model("B15")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        hashval = reproducible_hash(fmt + "b15")
+        random.seed(hashval)
 
-            bins_path = Path("coverage", "covergroups", "bins_templates", "generated")
-            bins_path.mkdir(parents=True, exist_ok=True)
+        bins_path = Path("coverage", "covergroups", "bins_templates", "generated")
+        bins_path.mkdir(parents=True, exist_ok=True)
 
-            add_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh"
-            mul_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_prod_special_sigs.svh"
-            with add_sigs_path.open("w") as add_sigs_file, mul_sigs_path.open("w") as mul_sigs_file:
-                print(f"Generating {fmt} Sigs & Shifts")
-                b9_sig_gen = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b15")
-                b9_sigs = [int(sig, 2) for sig in b9_sig_gen.generate(add_sigs_file)]
+        add_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh"
+        mul_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_prod_special_sigs.svh"
+        with add_sigs_path.open("w") as add_sigs_file, mul_sigs_path.open("w") as mul_sigs_file:
+            log_info(f"Generating {fmt} Sigs & Shifts")
+            b9_sig_gen = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b15")
+            b9_sigs = [int(sig, 2) for sig in b9_sig_gen.generate(add_sigs_file)]
 
-                b15_sig_gen = B15SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b15")
-                b15_sigs = [(int(sig1, 2), int(sig2, 2)) for sig1, sig2 in b15_sig_gen.generate(mul_sigs_file)]
+            b15_sig_gen = B15SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt, fmt + "b15")
+            b15_sigs = [(int(sig1, 2), int(sig2, 2)) for sig1, sig2 in b15_sig_gen.generate(mul_sigs_file)]
 
-                interesting_shifts = interesting_shift_ranges(2, 2, fmt)
+            interesting_shifts = interesting_shift_ranges(2, 2, fmt)
 
-                print(f"Generating {fmt} Tests")
-                interesting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)
-                uninteresting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+            log_info(f"Generating {fmt} Tests")
+            interesting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)
+            uninteresting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B15.py
+++ b/src/cover_float/testgen/B15.py
@@ -1,13 +1,14 @@
 # B15
 
 import itertools
+import logging
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, TextIO
+from typing import TYPE_CHECKING, Optional, TextIO, cast
 
 import cover_float.common.constants as constants
-from cover_float.common.log import log_error, log_info
+import cover_float.common.log as log
 from cover_float.common.util import (
     bezout_inverse,
     factors_to_bit_width,
@@ -18,6 +19,8 @@ from cover_float.common.util import (
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.B9 import B9SignificandGenerator
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B15"))
 
 if TYPE_CHECKING:
     # This block is seen by Pyright but ignored at runtime
@@ -383,7 +386,7 @@ class B15SignificandGenerator:
 
         hits = 0
         for attempt in range(10000):
-            log_info(f"Generating {self.fmt} Sparse Zeros: Generated: {hits}/10, Attempts: {attempt}")
+            logger.status(f"Generating {self.fmt} Sparse Zeros: Generated: {hits}/10, Attempts: {attempt}")
             target = (1 << (2 * self.nf + 2)) - 1
             for _ in range(min(8, self.nf // 2)):
                 p2 = random.randint(1, 2 * self.nf)
@@ -445,7 +448,7 @@ class B15SignificandGenerator:
 
             sig1_pattern = "10" * (teeth_length) + "1" * internal_ones_count + "01" * teeth_length
             if len(sig1_pattern) > self.nf + 1:
-                log_error(
+                logger.exception(
                     f"Invalid Arrangement for Long Run of Ones, offset={offset}, run_length={run_length} "
                     f"Generated Sig1: {sig1_pattern}, length={len(sig1_pattern)}"
                 )
@@ -513,7 +516,7 @@ class B15SignificandGenerator:
                         self.sigs.append(B15Significand(sig1, sig2, target))
                         break
                 else:
-                    log_error("Long Run Zeros Failed (factoring)")
+                    logger.exception("Long Run Zeros Failed (factoring)")
             elif run_length + offset - self.nf < 20:
                 # We can generally get away with the stochastic search here (limitation still exists for nf=112)
                 best = 2 * self.nf, 0, 0
@@ -551,7 +554,7 @@ class B15SignificandGenerator:
                         best = score, sig1, sig2
 
                 if best[0] != 0:
-                    log_error(f"Long Run Zeros Failed for {self.fmt}")
+                    logger.exception(f"Long Run Zeros Failed for {self.fmt}")
 
                 sig1 = bin(best[1])[3:]
                 sig2 = bin(best[2])[3:]
@@ -559,23 +562,23 @@ class B15SignificandGenerator:
                 self.sigs.append(B15Significand(sig1, sig2, res))
 
     def generate(self, file: TextIO) -> list[tuple[str, str]]:
-        log_info(f"Generating {self.fmt} Checker Boards")
+        logger.status(f"Generating {self.fmt} Checker Boards")
         self.checkerboards()
-        log_info(f"Generating {self.fmt} Trailing Zeros")
+        logger.status(f"Generating {self.fmt} Trailing Zeros")
         self.trailing_zeros()
-        log_info(f"Generating {self.fmt} Trailing Ones")
+        logger.status(f"Generating {self.fmt} Trailing Ones")
         self.trailing_ones()
-        log_info(f"Generating {self.fmt} Leading Zeros")
+        logger.status(f"Generating {self.fmt} Leading Zeros")
         self.leading_zeros()
-        log_info(f"Generating {self.fmt} Leading Ones")
+        logger.status(f"Generating {self.fmt} Leading Ones")
         self.leading_ones()
-        log_info(f"Generating {self.fmt} Sparse Ones")
+        logger.status(f"Generating {self.fmt} Sparse Ones")
         self.sparse_ones()
-        log_info(f"Generating {self.fmt} Sparse Zeros")
+        logger.status(f"Generating {self.fmt} Sparse Zeros")
         self.sparse_zeros()
-        log_info(f"Generating {self.fmt} Long Runs of Ones")
+        logger.status(f"Generating {self.fmt} Long Runs of Ones")
         self.long_run_ones()
-        log_info(f"Generating {self.fmt} Long Runs of Zeros")
+        logger.status(f"Generating {self.fmt} Long Runs of Zeros")
         self.long_run_zeros()
 
         self.store_sigs(file)
@@ -719,7 +722,7 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
         add_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh"
         mul_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_prod_special_sigs.svh"
         with add_sigs_path.open("w") as add_sigs_file, mul_sigs_path.open("w") as mul_sigs_file:
-            log_info(f"Generating {fmt} Sigs & Shifts")
+            logger.status(f"Generating {fmt} Sigs & Shifts")
             b9_sig_gen = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b15")
             b9_sigs = [int(sig, 2) for sig in b9_sig_gen.generate(add_sigs_file)]
 
@@ -728,6 +731,6 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
 
             interesting_shifts = interesting_shift_ranges(2, 2, fmt)
 
-            log_info(f"Generating {fmt} Tests")
+            logger.status(f"Generating {fmt} Tests")
             interesting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)
             uninteresting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B2.py
+++ b/src/cover_float/testgen/B2.py
@@ -6,9 +6,8 @@ Last Edited:     April 10, 2026
 """
 
 import random
-from pathlib import Path
 from random import seed
-from typing import Callable
+from typing import Callable, TextIO
 
 from cover_float.common.constants import (
     BIAS,
@@ -33,6 +32,7 @@ from cover_float.common.util import (
     reproducible_hash,
 )
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 ZERO = "0" * 32
 
@@ -164,71 +164,64 @@ class Generator:
         return self.solve_exact(op, desired, builder)
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B2_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B2_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in FLOAT_FMTS:
-            gen = Generator(fmt)
+@register_model("B2")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in FLOAT_FMTS:
+        gen = Generator(fmt)
 
-            bases = {
-                "Zero": (0, 0),
-                "One": (0, (1 << (EXPONENT_BITS[fmt] - 1)) - 1),
-                "MinSub": (1, 0),
-                "MaxSub": ((1 << gen.m_bits) - 1, 0),
-                "MinNorm": (0, 1),
-                "MaxNorm": ((1 << gen.m_bits) - 1, (1 << EXPONENT_BITS[fmt]) - 2),
-            }
+        bases = {
+            "Zero": (0, 0),
+            "One": (0, (1 << (EXPONENT_BITS[fmt] - 1)) - 1),
+            "MinSub": (1, 0),
+            "MaxSub": ((1 << gen.m_bits) - 1, 0),
+            "MinNorm": (0, 1),
+            "MaxNorm": ((1 << gen.m_bits) - 1, (1 << EXPONENT_BITS[fmt]) - 2),
+        }
 
-            for base, (base_m, base_e) in bases.items():
-                maxnorm = base == "MaxNorm"
+        for base, (base_m, base_e) in bases.items():
+            maxnorm = base == "MaxNorm"
 
-                for i in range(gen.m_bits):
-                    for sign in [0, 1]:
-                        desired = decimal_components_to_hex(fmt, sign, base_e, base_m ^ (1 << i))
-                        seed(reproducible_hash(f"{fmt}_{base}_{i}_{sign}"))
+            for i in range(gen.m_bits):
+                for sign in [0, 1]:
+                    desired = decimal_components_to_hex(fmt, sign, base_e, base_m ^ (1 << i))
+                    seed(reproducible_hash(f"{fmt}_{base}_{i}_{sign}"))
 
-                        a, b, c = gen.gen_add(desired, base_e, maxnorm, sign)
-                        vec = generate_test_vector(OP_ADD, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                        run_and_store_test_vector(vec, test_f, cover_f)
-
-                        a, b, c = gen.gen_sub(desired, base_e, maxnorm, sign)
-                        vec = generate_test_vector(OP_SUB, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                        run_and_store_test_vector(vec, test_f, cover_f)
-
-                        a, b, c = gen.gen_mul(desired, maxnorm, sign)
-                        vec = generate_test_vector(OP_MUL, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                        run_and_store_test_vector(vec, test_f, cover_f)
-
-                        a, b, c = gen.gen_div(desired, maxnorm, sign)
-                        vec = generate_test_vector(OP_DIV, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                        run_and_store_test_vector(vec, test_f, cover_f)
-
-                        if sign == 0 and base == "One":
-                            a, b, c = gen.gen_sqrt(desired)
-                            vec = generate_test_vector(OP_SQRT, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                            run_and_store_test_vector(vec, test_f, cover_f)
-
-                        for op in [OP_FMADD, OP_FMSUB, OP_FNMADD, OP_FNMSUB]:
-                            a, b, c = gen.gen_fma(op, desired, base_e, maxnorm)
-                            vec = generate_test_vector(op, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                            run_and_store_test_vector(vec, test_f, cover_f)
-
-                # for -0 cases
-                if base == "Zero":
-                    desired = decimal_components_to_hex(fmt, 1, 0, 0)
-
-                    seed(reproducible_hash(f"{fmt}_zero_add_1"))
-                    a, b, c = gen.gen_add(desired, 0, False, 1)
+                    a, b, c = gen.gen_add(desired, base_e, maxnorm, sign)
                     vec = generate_test_vector(OP_ADD, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
                     run_and_store_test_vector(vec, test_f, cover_f)
 
-                    seed(reproducible_hash(f"{fmt}_zero_sub_1"))
-                    a, b, c = gen.gen_sub(desired, 0, False, 1)
+                    a, b, c = gen.gen_sub(desired, base_e, maxnorm, sign)
                     vec = generate_test_vector(OP_SUB, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
                     run_and_store_test_vector(vec, test_f, cover_f)
 
+                    a, b, c = gen.gen_mul(desired, maxnorm, sign)
+                    vec = generate_test_vector(OP_MUL, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
+                    run_and_store_test_vector(vec, test_f, cover_f)
 
-if __name__ == "__main__":
-    main()
+                    a, b, c = gen.gen_div(desired, maxnorm, sign)
+                    vec = generate_test_vector(OP_DIV, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
+                    run_and_store_test_vector(vec, test_f, cover_f)
+
+                    if sign == 0 and base == "One":
+                        a, b, c = gen.gen_sqrt(desired)
+                        vec = generate_test_vector(OP_SQRT, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
+                        run_and_store_test_vector(vec, test_f, cover_f)
+
+                    for op in [OP_FMADD, OP_FMSUB, OP_FNMADD, OP_FNMSUB]:
+                        a, b, c = gen.gen_fma(op, desired, base_e, maxnorm)
+                        vec = generate_test_vector(op, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
+                        run_and_store_test_vector(vec, test_f, cover_f)
+
+            # for -0 cases
+            if base == "Zero":
+                desired = decimal_components_to_hex(fmt, 1, 0, 0)
+
+                seed(reproducible_hash(f"{fmt}_zero_add_1"))
+                a, b, c = gen.gen_add(desired, 0, False, 1)
+                vec = generate_test_vector(OP_ADD, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
+                run_and_store_test_vector(vec, test_f, cover_f)
+
+                seed(reproducible_hash(f"{fmt}_zero_sub_1"))
+                a, b, c = gen.gen_sub(desired, 0, False, 1)
+                vec = generate_test_vector(OP_SUB, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
+                run_and_store_test_vector(vec, test_f, cover_f)

--- a/src/cover_float/testgen/B2.py
+++ b/src/cover_float/testgen/B2.py
@@ -5,10 +5,12 @@ Created:         April 8, 2026
 Last Edited:     April 10, 2026
 """
 
+import logging
 import random
 from random import seed
-from typing import Callable, TextIO
+from typing import Callable, TextIO, cast
 
+import cover_float.common.log as log
 from cover_float.common.constants import (
     BIAS,
     BIASED_EXP,
@@ -33,6 +35,8 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B2"))
 
 ZERO = "0" * 32
 

--- a/src/cover_float/testgen/B20.py
+++ b/src/cover_float/testgen/B20.py
@@ -2,12 +2,13 @@
 
 import math
 import random
-from pathlib import Path
 from typing import TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.log import log_error
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
 from cover_float.reference import run_and_store_test_vector, run_test_vector, store_cover_vector
+from cover_float.testgen.model import register_model
 
 
 def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -42,10 +43,7 @@ def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         # Extract Number of trailing zeros for verification
         generated_trailing_zeros = len(bin(res)) - len(bin(res).rstrip("0"))
         if generated_trailing_zeros != trailing_zeros:
-            print(
-                f"B20 Error: Failed to Generate A Div Result for format {fmt} with "
-                f"exactly {trailing_zeros} trailing_zeros"
-            )
+            log_error(f"Failed to Generate A Div Result for format {fmt} with exactly {trailing_zeros} trailing_zeros")
             continue
 
         exp1, exp2 = random.randint(min_exp, max_exp), random.randint(min_exp, max_exp)
@@ -102,24 +100,16 @@ def generate_sqrt_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         mantissa |= 1 << nf
 
         if mantissa != answer:
-            print(
-                f"B20 Error: Failed to Generate a SQRT Value for format: {fmt} and number of "
-                f"trailing zeros: {trailing_zeros}"
+            log_error(
+                f"Failed to Generate a SQRT Value for format: {fmt} and number of trailing zeros: {trailing_zeros}"
             )
             continue
 
         store_cover_vector(result, test_f, cover_f)
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B20_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B20_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            generate_div_tests(fmt, test_f, cover_f)
-            generate_sqrt_tests(fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B20")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        generate_div_tests(fmt, test_f, cover_f)
+        generate_sqrt_tests(fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B20.py
+++ b/src/cover_float/testgen/B20.py
@@ -1,14 +1,17 @@
 # B20 (rwolk@g.hmc.edu)
 
+import logging
 import math
 import random
-from typing import TextIO
+from typing import TextIO, cast
 
 import cover_float.common.constants as constants
-from cover_float.common.log import log_error
+import cover_float.common.log as log
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
 from cover_float.reference import run_and_store_test_vector, run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
 
 
 def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -43,7 +46,9 @@ def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         # Extract Number of trailing zeros for verification
         generated_trailing_zeros = len(bin(res)) - len(bin(res).rstrip("0"))
         if generated_trailing_zeros != trailing_zeros:
-            log_error(f"Failed to Generate A Div Result for format {fmt} with exactly {trailing_zeros} trailing_zeros")
+            logger.exception(
+                f"Failed to Generate A Div Result for format {fmt} with exactly {trailing_zeros} trailing_zeros"
+            )
             continue
 
         exp1, exp2 = random.randint(min_exp, max_exp), random.randint(min_exp, max_exp)
@@ -100,7 +105,7 @@ def generate_sqrt_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         mantissa |= 1 << nf
 
         if mantissa != answer:
-            log_error(
+            logger.exception(
                 f"Failed to Generate a SQRT Value for format: {fmt} and number of trailing zeros: {trailing_zeros}"
             )
             continue

--- a/src/cover_float/testgen/B21.py
+++ b/src/cover_float/testgen/B21.py
@@ -2,7 +2,6 @@
 # B21 Model
 
 import random
-from pathlib import Path
 from random import seed
 from typing import TextIO
 
@@ -17,6 +16,7 @@ from cover_float.common.constants import (
 )
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 
 def generate_FP(precision: str, input_sign: str, input_exponent: int, input_mantissa: int) -> str:
@@ -94,13 +94,6 @@ def genTests(test_f: TextIO, cover_f: TextIO) -> None:
                         )
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B21_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B21_cv.txt").open("w") as cover_f,
-    ):
-        genTests(test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B20")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    genTests(test_f, cover_f)

--- a/src/cover_float/testgen/B25.py
+++ b/src/cover_float/testgen/B25.py
@@ -1,12 +1,12 @@
 # B25 (rwolk@g.hmc.edu)
 
 import random
-from pathlib import Path
 from typing import TextIO
 
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 
 def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -63,14 +63,7 @@ def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         run_and_store_test_vector(tv, test_f, cover_f)
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B25_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B25_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.INT_FMTS:
-            generate_B25(fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B25")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.INT_FMTS:
+        generate_B25(fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B26.py
+++ b/src/cover_float/testgen/B26.py
@@ -1,12 +1,12 @@
 # B26 (rwolk@g.hmc.edu)
 
 import random
-from pathlib import Path
 from typing import TextIO
 
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 
 def generate_B26(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -33,14 +33,7 @@ def generate_B26(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 run_and_store_test_vector(tv, test_f, cover_f)
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B26_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B26_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.INT_FMTS:
-            generate_B26(fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B26")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.INT_FMTS:
+        generate_B26(fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B27.py
+++ b/src/cover_float/testgen/B27.py
@@ -2,12 +2,12 @@
 
 import itertools
 import random
-from pathlib import Path
 from typing import TextIO
 
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 
 def generate_B27(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -39,14 +39,7 @@ def generate_B27(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             run_and_store_test_vector(tv, test_f, cover_f)
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B27_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B27_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            generate_B27(fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B27")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        generate_B27(fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B29.py
+++ b/src/cover_float/testgen/B29.py
@@ -1,12 +1,13 @@
 # B29 (rwolk@g.hmc.edu)
 
 import random
-from pathlib import Path
 from typing import TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.log import log_error
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
 from cover_float.reference import run_test_vector, store_cover_vector
+from cover_float.testgen.model import register_model
 
 
 def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -54,17 +55,10 @@ def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             if computed_info == target:
                 store_cover_vector(results, test_f, cover_f)
             else:
-                print(f"B29 Generation Error: fmt={fmt}, and target={target}")
+                log_error(f"fmt={fmt} and target={target}")
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B29_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B29_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            generate_tests(fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B29")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        generate_tests(fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B29.py
+++ b/src/cover_float/testgen/B29.py
@@ -1,13 +1,16 @@
 # B29 (rwolk@g.hmc.edu)
 
+import logging
 import random
-from typing import TextIO
+from typing import TextIO, cast
 
 import cover_float.common.constants as constants
-from cover_float.common.log import log_error
+import cover_float.common.log as log
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
 from cover_float.reference import run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
 
 
 def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -55,7 +58,7 @@ def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             if computed_info == target:
                 store_cover_vector(results, test_f, cover_f)
             else:
-                log_error(f"fmt={fmt} and target={target}")
+                logger.exception(f"Failed to Generate for fmt={fmt} and target={target}")
 
 
 @register_model("B29")

--- a/src/cover_float/testgen/B3.py
+++ b/src/cover_float/testgen/B3.py
@@ -1,8 +1,9 @@
+import logging
 import random
-from typing import Optional, TextIO
+from typing import Optional, TextIO, cast
 
 import cover_float.common.constants as common
-from cover_float.common.log import log_error
+import cover_float.common.log as log
 from cover_float.common.util import (
     extract_rounding_info,
     generate_float,
@@ -13,6 +14,8 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B3"))
 
 SRC1_OPS = [common.OP_SQRT]
 
@@ -192,7 +195,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
                 fields = unpack_test_vector(result)
                 if (sigA * sigB) != fields.fma_pre_addition:
-                    log_error(
+                    logger.exception(
                         "FMA PreAddition is being Incorrectly Calculated, Please Investigate"
                         f" {in1:x} * {in2:x} + {in3:x}"
                     )
@@ -200,7 +203,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 rounding = extract_rounding_info(result)
 
                 if rounding["Sticky"] != 0:
-                    log_error(
+                    logger.exception(
                         "FMA Sticky Bit Generation Failed! This should not happen, please investigate "
                         f"Inputs: signA={signA}, sigA={sigA:#x}, expA={expA}, signB={signB}, sigB={sigB:#x}, "
                         f"expB={expB}, fmt={fmt}, op={op}"
@@ -215,7 +218,9 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                         break
             else:
                 # This catches a for loop that does not break, i.e. we don't hit every goal
-                log_error(f"FMA Generation Failed for fmt={fmt}, mode={mode}, with to_cover={to_cover} goals remaining")
+                logger.exception(
+                    f"FMA Generation Failed for fmt={fmt}, mode={mode}, with to_cover={to_cover} goals remaining"
+                )
 
 
 def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
@@ -280,7 +285,7 @@ def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 if info == target:
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    log_error(
+                    logger.exception(
                         f"AddSub test generation failed: op={op}, target={target}, last_digits={last_digits}, "
                         f"A={A}, B={B}"
                     )
@@ -344,7 +349,9 @@ def write_mul_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 if len(goals) == 0:
                     break
         else:
-            log_error(f"Failed to generate mul cover_vectors for fmt={fmt}, mode={mode}. Remaining cases {goals}")
+            logger.exception(
+                f"Failed to generate mul cover_vectors for fmt={fmt}, mode={mode}. Remaining cases {goals}"
+            )
 
 
 def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
@@ -404,7 +411,7 @@ def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
         info = extract_rounding_info(result)
 
         if info not in targets:
-            log_error(
+            logger.exception(
                 f"sqrt generation sticky bit generation failed, please investigate: mantissa={mantissa:x}, exp={exp}"
             )
 
@@ -414,7 +421,7 @@ def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             gen_square = int(result_mul.split("_")[-6], 16)
 
             if float_ != gen_square:
-                log_error(f"sqrt float should have been: {gen_square:x}, was {float_:x}")
+                logger.exception(f"sqrt float should have been: {gen_square:x}, was {float_:x}")
                 return
         else:
             store_cover_vector(result, test_f, cover_f)
@@ -489,7 +496,7 @@ def write_div_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             sig_quotient = (sig1_64) // sig2
 
             if sig_quotient * sig2 != sig1_64:
-                log_error(
+                logger.exception(
                     f"Failed to generate exact division result, please investigate: target={target} K={K}, "
                     f"odd_factors={odd_factors}, sig1={sig1:x}, sig2={sig2:x}"
                 )
@@ -526,7 +533,7 @@ def write_div_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             """
 
             if info != target:
-                log_error(
+                logger.exception(
                     f"Failed to generate exact division result, please investigate: target={target}, K={K}, "
                     f"odd_factors={odd_factors}, sig1={sig1:x}, sig2={sig2:x}"
                 )
@@ -619,7 +626,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 }
 
                 if expected_result != info:
-                    log_error(
+                    logger.exception(
                         f"CFI Generation Unexpected Value, fmt={fmt}, target={target_fmt}, mode={mode},"
                         f"cvt_from={cvt_from:x}"
                     )
@@ -630,7 +637,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     if len(goals) == 0:
                         break
             else:
-                log_error(
+                logger.exception(
                     f"CFI Generation Failed: fmt={fmt}, target={target_fmt}, mode={mode}, remaining_goals={goals}"
                 )
 
@@ -670,7 +677,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     if len(goals) == 0:
                         break
             else:
-                log_error(
+                logger.exception(
                     f"CFF Generation Failed: fmt={fmt}, target_fmt={target_fmt}, mode={mode}, remaining_goals={goals}"
                 )
 
@@ -713,7 +720,9 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     if len(goals) == 0:
                         break
             else:
-                log_error(f"CIF Test Gen Failed: fmt={fmt}, from={target_fmt}, mode={mode}, remaining_goals={goals}")
+                logger.exception(
+                    f"CIF Test Gen Failed: fmt={fmt}, from={target_fmt}, mode={mode}, remaining_goals={goals}"
+                )
 
 
 @register_model("B3")
@@ -763,4 +772,6 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
                     if len(cover_goals) == 0:
                         break
                 else:
-                    log_error(f"Sticky=1 Random Generation Miss: op={op}, fmt={fmt}, goals_remaining={cover_goals}")
+                    logger.exception(
+                        f"Sticky=1 Random Generation Miss: op={op}, fmt={fmt}, goals_remaining={cover_goals}"
+                    )

--- a/src/cover_float/testgen/B3.py
+++ b/src/cover_float/testgen/B3.py
@@ -1,8 +1,8 @@
 import random
-from pathlib import Path
 from typing import Optional, TextIO
 
 import cover_float.common.constants as common
+from cover_float.common.log import log_error
 from cover_float.common.util import (
     extract_rounding_info,
     generate_float,
@@ -12,6 +12,7 @@ from cover_float.common.util import (
     unpack_test_vector,
 )
 from cover_float.reference import run_test_vector, store_cover_vector
+from cover_float.testgen.model import register_model
 
 SRC1_OPS = [common.OP_SQRT]
 
@@ -191,15 +192,17 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
                 fields = unpack_test_vector(result)
                 if (sigA * sigB) != fields.fma_pre_addition:
-                    print("FMA PreAddition is being Incorrectly Calculated, Please Investigate")
-                    print("\t{in1:x} * {in2:x} + {in3:x}")
+                    log_error(
+                        "FMA PreAddition is being Incorrectly Calculated, Please Investigate"
+                        f" {in1:x} * {in2:x} + {in3:x}"
+                    )
 
                 rounding = extract_rounding_info(result)
 
                 if rounding["Sticky"] != 0:
-                    print("FMA Sticky Bit Generation Failed! This should not happen, please investigate")
-                    print(
-                        f"\tInputs: signA={signA}, sigA={sigA:#x}, expA={expA}, signB={signB}, sigB={sigB:#x}, "
+                    log_error(
+                        "FMA Sticky Bit Generation Failed! This should not happen, please investigate "
+                        f"Inputs: signA={signA}, sigA={sigA:#x}, expA={expA}, signB={signB}, sigB={sigB:#x}, "
                         f"expB={expB}, fmt={fmt}, op={op}"
                     )
 
@@ -212,7 +215,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                         break
             else:
                 # This catches a for loop that does not break, i.e. we don't hit every goal
-                print(fmt, mode, to_cover)
+                log_error(f"FMA Generation Failed for fmt={fmt}, mode={mode}, with to_cover={to_cover} goals remaining")
 
 
 def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
@@ -277,9 +280,8 @@ def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 if info == target:
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    breakpoint()
-                    print(
-                        f"AddSub test generation failed: op={op}, target={target}, last_digits={last_digits},"
+                    log_error(
+                        f"AddSub test generation failed: op={op}, target={target}, last_digits={last_digits}, "
                         f"A={A}, B={B}"
                     )
 
@@ -342,7 +344,7 @@ def write_mul_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 if len(goals) == 0:
                     break
         else:
-            print(f"Failed to generate mul cover_vectors for fmt={fmt}, mode={mode}. Remaining cases {goals}")
+            log_error(f"Failed to generate mul cover_vectors for fmt={fmt}, mode={mode}. Remaining cases {goals}")
 
 
 def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
@@ -402,7 +404,9 @@ def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
         info = extract_rounding_info(result)
 
         if info not in targets:
-            print(f"sqrt generation sticky bit generation failed, please investigate: mantissa={mantissa:x}, exp={exp}")
+            log_error(
+                f"sqrt generation sticky bit generation failed, please investigate: mantissa={mantissa:x}, exp={exp}"
+            )
 
             float_2 = generate_float(0, exp, mantissa & mask, fmt)
             tv_mul = generate_test_vector(common.OP_MUL, float_2, float_2, 0, fmt, fmt)
@@ -410,7 +414,7 @@ def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             gen_square = int(result_mul.split("_")[-6], 16)
 
             if float_ != gen_square:
-                print(f"sqrt float should have been: {gen_square:x}, was {float_:x}")
+                log_error(f"sqrt float should have been: {gen_square:x}, was {float_:x}")
                 return
         else:
             store_cover_vector(result, test_f, cover_f)
@@ -485,8 +489,8 @@ def write_div_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             sig_quotient = (sig1_64) // sig2
 
             if sig_quotient * sig2 != sig1_64:
-                print(
-                    f"Failed to generate exact division result, please investigate: target={target} K={K},"
+                log_error(
+                    f"Failed to generate exact division result, please investigate: target={target} K={K}, "
                     f"odd_factors={odd_factors}, sig1={sig1:x}, sig2={sig2:x}"
                 )
                 continue
@@ -522,9 +526,8 @@ def write_div_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             """
 
             if info != target:
-                print(info, target)
-                print(
-                    f"Failed to generate exact division result, please investigate: target={target}, K={K},"
+                log_error(
+                    f"Failed to generate exact division result, please investigate: target={target}, K={K}, "
                     f"odd_factors={odd_factors}, sig1={sig1:x}, sig2={sig2:x}"
                 )
             else:
@@ -616,7 +619,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 }
 
                 if expected_result != info:
-                    print(
+                    log_error(
                         f"CFI Generation Unexpected Value, fmt={fmt}, target={target_fmt}, mode={mode},"
                         f"cvt_from={cvt_from:x}"
                     )
@@ -627,7 +630,9 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     if len(goals) == 0:
                         break
             else:
-                print(f"CFI Generation Failed: fmt={fmt}, target={target_fmt}, mode={mode}, remaining_goals={goals}")
+                log_error(
+                    f"CFI Generation Failed: fmt={fmt}, target={target_fmt}, mode={mode}, remaining_goals={goals}"
+                )
 
     # CFF Test Gen: We choose fmt to be the target
     for mode in common.ROUNDING_MODES:
@@ -665,7 +670,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     if len(goals) == 0:
                         break
             else:
-                print(
+                log_error(
                     f"CFF Generation Failed: fmt={fmt}, target_fmt={target_fmt}, mode={mode}, remaining_goals={goals}"
                 )
 
@@ -708,65 +713,54 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     if len(goals) == 0:
                         break
             else:
-                print(f"CIF Test Gen Failed: fmt={fmt}, from={target_fmt}, mode={mode}, remaining_goals={goals}")
+                log_error(f"CIF Test Gen Failed: fmt={fmt}, from={target_fmt}, mode={mode}, remaining_goals={goals}")
 
 
-def main() -> None:
+@register_model("B3")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
     random.seed(reproducible_hash("B3"))
 
-    with (
-        Path("./tests/testvectors/B3_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B3_cv.txt").open("w") as cover_f,
-    ):
-        # These are going to be for sticky = 0
+    # These are going to be for sticky = 0
+    for fmt in common.FLOAT_FMTS:
+        write_add_sub_tests(test_f, cover_f, fmt)
+        write_mul_tests(test_f, cover_f, fmt)
+        write_div_tests(test_f, cover_f, fmt)
+        write_sqrt_tests(test_f, cover_f, fmt)
+        write_fma_tests(test_f, cover_f, fmt)
+        write_cvt_tests(test_f, cover_f, fmt)
+
+    targets = [
+        {
+            "Sign": (x & 1),
+            "LSB": (x & 2) >> 1,
+            "Guard": (x & 4) >> 2,
+            "Sticky": (x & 8) >> 3,  # Sticky is one for all of these
+        }
+        for x in range(8, 16)
+    ]
+
+    for op in [*SRC1_OPS, *SRC2_OPS, *SRC3_OPS]:
         for fmt in common.FLOAT_FMTS:
-            write_add_sub_tests(test_f, cover_f, fmt)
-            write_mul_tests(test_f, cover_f, fmt)
-            write_div_tests(test_f, cover_f, fmt)
-            write_sqrt_tests(test_f, cover_f, fmt)
-            write_fma_tests(test_f, cover_f, fmt)
-            write_cvt_tests(test_f, cover_f, fmt)
+            for mode in common.ROUNDING_MODES:
+                cover_goals = targets[:]
+                if op == common.OP_SQRT or op == common.OP_REM:
+                    cover_goals = [x for x in cover_goals if x["Sign"] == 0]
 
-        targets = [
-            {
-                "Sign": (x & 1),
-                "LSB": (x & 2) >> 1,
-                "Guard": (x & 4) >> 2,
-                "Sticky": (x & 8) >> 3,  # Sticky is one for all of these
-            }
-            for x in range(8, 16)
-        ]
+                for _ in range(200):
+                    in1 = generate_random_float(random.randint(0, 5), fmt)
+                    in2 = generate_random_float(random.randint(0, 5), fmt) if op in SRC2_OPS or op in SRC3_OPS else 0
+                    in3 = generate_random_float(random.randint(0, 5), fmt) if op in SRC3_OPS else 0
 
-        for op in [*SRC1_OPS, *SRC2_OPS, *SRC3_OPS]:
-            for fmt in common.FLOAT_FMTS:
-                for mode in common.ROUNDING_MODES:
-                    cover_goals = targets[:]
-                    if op == common.OP_SQRT or op == common.OP_REM:
-                        cover_goals = [x for x in cover_goals if x["Sign"] == 0]
+                    tv = generate_test_vector(op, in1, in2, in3, fmt, fmt, mode)
+                    cv = run_test_vector(tv)
 
-                    for _ in range(200):
-                        in1 = generate_random_float(random.randint(0, 5), fmt)
-                        in2 = (
-                            generate_random_float(random.randint(0, 5), fmt) if op in SRC2_OPS or op in SRC3_OPS else 0
-                        )
-                        in3 = generate_random_float(random.randint(0, 5), fmt) if op in SRC3_OPS else 0
+                    rounding_results = extract_rounding_info(cv)
 
-                        tv = generate_test_vector(op, in1, in2, in3, fmt, fmt, mode)
-                        cv = run_test_vector(tv)
+                    if rounding_results in cover_goals:
+                        cover_goals.remove(rounding_results)
+                        store_cover_vector(cv, test_f, cover_f)
 
-                        rounding_results = extract_rounding_info(cv)
-
-                        if rounding_results in cover_goals:
-                            cover_goals.remove(rounding_results)
-                            store_cover_vector(cv, test_f, cover_f)
-
-                        if len(cover_goals) == 0:
-                            break
-                    else:
-                        print("Miss: ", op, fmt, len(cover_goals), cover_goals)
-
-        print("B3 Tests Generated!")
-
-
-if __name__ == "__main__":
-    main()
+                    if len(cover_goals) == 0:
+                        break
+                else:
+                    log_error(f"Sticky=1 Random Generation Miss: op={op}, fmt={fmt}, goals_remaining={cover_goals}")

--- a/src/cover_float/testgen/B6.py
+++ b/src/cover_float/testgen/B6.py
@@ -3,7 +3,6 @@
 
 
 import random
-from pathlib import Path
 from random import seed
 from typing import TextIO
 
@@ -27,6 +26,7 @@ from cover_float.common.constants import (
 )
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 B6_FMTS = [FMT_QUAD, FMT_DOUBLE, FMT_SINGLE, FMT_BF16, FMT_HALF]
 ROUNDING_MODES = ["00", "01", "02", "03", "04", "05"]
@@ -574,14 +574,7 @@ def createTests(test_f: TextIO, cover_f: TextIO) -> None:
                             )
 
 
-def main() -> None:
-    with (
-        Path("./tests/testvectors/B6_tv.txt").open("w") as test_f,
-        Path("./tests/covervectors/B6_cv.txt").open("w") as cover_f,
-    ):
-        convertTests(test_f, cover_f)
-        createTests(test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B6")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    convertTests(test_f, cover_f)
+    createTests(test_f, cover_f)

--- a/src/cover_float/testgen/B7.py
+++ b/src/cover_float/testgen/B7.py
@@ -499,7 +499,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         # the leading one from the multiplication mantissa is in the lsb
         placements: list[int] = []
 
-        with logger.progress_bar("B7", status=f"{fmt} FMA Target Placements", show_m_of_n=True) as pbar:
+        with logger.progress_bar(status=f"{fmt} FMA Target Placements", show_m_of_n=True) as pbar:
             for target_placement in pbar.track(range(1, 2 * constants.MANTISSA_BITS[fmt])):
                 # We want the lowest possible exponent difference
                 shift_amount = max(3, target_placement - constants.MANTISSA_BITS[fmt] + 1)

--- a/src/cover_float/testgen/B7.py
+++ b/src/cover_float/testgen/B7.py
@@ -498,7 +498,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         # the leading one from the multiplication mantissa is in the lsb
         placements: list[int] = []
 
-        with logger.status_reporter.progress_bar("B7", status=f"{fmt} FMA Target Placements", show_m_of_n=True) as pbar:
+        with logger.progress_bar("B7", status=f"{fmt} FMA Target Placements", show_m_of_n=True) as pbar:
             for target_placement in pbar.track(range(1, 2 * constants.MANTISSA_BITS[fmt])):
                 # if target_placement > STICKY_LIMITS.get(fmt, 1000):
                 #     # The things that are possible within what softfloat gives us

--- a/src/cover_float/testgen/B7.py
+++ b/src/cover_float/testgen/B7.py
@@ -9,11 +9,12 @@
 #   This excludes DIV and SQRT as targeting specific sticky values is impossible
 
 import functools
+import logging
 import random
-from typing import TYPE_CHECKING, Optional, TextIO
+from typing import TYPE_CHECKING, Optional, TextIO, cast
 
 import cover_float.common.constants as constants
-from cover_float.common.log import log_error, progress_bar
+import cover_float.common.log as log
 from cover_float.common.util import (
     bezout_inverse,
     factors_to_bit_width,
@@ -23,6 +24,8 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B7"))
 
 if TYPE_CHECKING:
     # This block is seen by Pyright but ignored at runtime
@@ -80,7 +83,7 @@ def add_sub_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             rounding_bits = rounding_bits[:nf]
 
             if int(rounding_bits, 2) != 1 << (nf - extra_bit - 1):
-                log_error(f"Add Sub Generation Failed: extra_bit: {extra_bit}, op: {op}")
+                logger.exception(f"Add Sub Generation Failed: extra_bit: {extra_bit}, op: {op}")
             else:
                 store_cover_vector(result, test_f, cover_f)
 
@@ -172,7 +175,7 @@ def mul_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             if hit_with_shift and hit_without_shift:
                 break
         else:
-            log_error(
+            logger.exception(
                 f"Failure to generate mul tests, fmt={fmt}, extra_bit={extra_bit}, hit_with_shift={hit_with_shift}, "
                 f"hit_without_shift={hit_without_shift}"
             )
@@ -417,9 +420,9 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                     store_cover_vector(result, test_f, cover_f)
                     break
                 if actual_extra_bits[1:] == expected_extra_bits[1:]:
-                    log_error("Failure in FMA Test Generation, failed to create the expected bits")
+                    logger.exception("Failure in FMA Test Generation, failed to create the expected bits")
             else:
-                log_error("Failure to generate a Guard=0 Case in FMA Testgen")
+                logger.exception("Failure to generate a Guard=0 Case in FMA Testgen")
 
         # Now do the addend hanging off of the end of the mantissa
         # This will be the (2nf + 1)th extra bit
@@ -478,7 +481,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                     store_cover_vector(result, test_f, cover_f)
                     break
             else:
-                log_error(
+                logger.exception(
                     f"Failure to generate big multiplication, small, far addend for fma with sticky = {overhang_extra}"
                     f" in fmt: {fmt}"
                 )
@@ -495,107 +498,106 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         # the leading one from the multiplication mantissa is in the lsb
         placements: list[int] = []
 
-        for target_placement in progress_bar(
-            range(1, 2 * constants.MANTISSA_BITS[fmt]), desc=f"{fmt} FMA Target Placements", miniters=1
-        ):
-            # if target_placement > STICKY_LIMITS.get(fmt, 1000):
-            #     # The things that are possible within what softfloat gives us
-            #     break
+        with logger.status_reporter.progress_bar("B7", status=f"{fmt} FMA Target Placements", show_m_of_n=True) as pbar:
+            for target_placement in pbar.track(range(1, 2 * constants.MANTISSA_BITS[fmt])):
+                # if target_placement > STICKY_LIMITS.get(fmt, 1000):
+                #     # The things that are possible within what softfloat gives us
+                #     break
 
-            # We want the lowest possible exponent difference
-            shift_amount = max(3, target_placement - constants.MANTISSA_BITS[fmt] + 1)
-            target_location = target_placement - shift_amount
+                # We want the lowest possible exponent difference
+                shift_amount = max(3, target_placement - constants.MANTISSA_BITS[fmt] + 1)
+                target_location = target_placement - shift_amount
 
-            if target_placement < STICKY_LIMITS.get(fmt, 1000):
-                attempted_sigs = multiplicand_generator(
-                    target_location, shift_amount, effective_subtraction, constants.MANTISSA_BITS[fmt]
-                )
-            else:
-                attempted_sigs = None
+                if target_placement < STICKY_LIMITS.get(fmt, 1000):
+                    attempted_sigs = multiplicand_generator(
+                        target_location, shift_amount, effective_subtraction, constants.MANTISSA_BITS[fmt]
+                    )
+                else:
+                    attempted_sigs = None
 
-            if attempted_sigs is None:
-                if not effective_subtraction:
-                    sigA, sigB = one_placements[middle_one]
-                    exp_diff = target_placement - middle_one + constants.MANTISSA_BITS[fmt] + 1
-                    if exp_diff > constants.MANTISSA_BITS[fmt]:
-                        sigA, sigB = one_placements[lowest_one]
-                        exp_diff = target_placement - lowest_one + constants.MANTISSA_BITS[fmt] + 1
+                if attempted_sigs is None:
+                    if not effective_subtraction:
+                        sigA, sigB = one_placements[middle_one]
+                        exp_diff = target_placement - middle_one + constants.MANTISSA_BITS[fmt] + 1
+                        if exp_diff > constants.MANTISSA_BITS[fmt]:
+                            sigA, sigB = one_placements[lowest_one]
+                            exp_diff = target_placement - lowest_one + constants.MANTISSA_BITS[fmt] + 1
+
+                            if exp_diff > constants.MANTISSA_BITS[fmt]:
+                                continue
+                    else:
+                        # 1st attempt all ones in the significand
+                        target = (1 << 2 * constants.MANTISSA_BITS[fmt] + 1) - 1
+                        factors = cached_factorint(target)
+                        f1, f2 = factors_to_bit_width(factors, target, constants.MANTISSA_BITS[fmt] + 1)
+
+                        if f1 * f2 == target:
+                            sigA, sigB = f1, f2
+                            one_location = 2 * constants.MANTISSA_BITS[fmt]  # After the decimal point
+                        else:
+                            sigA = (1 << constants.MANTISSA_BITS[fmt] + 1) - 2
+                            sigB = (1 << constants.MANTISSA_BITS[fmt]) + 1
+                            # These are the second best thing we can do
+                            one_location = 2 * constants.MANTISSA_BITS[fmt] - 1
+
+                        exp_diff = target_placement - one_location + constants.MANTISSA_BITS[fmt] + 1
 
                         if exp_diff > constants.MANTISSA_BITS[fmt]:
                             continue
                 else:
-                    # 1st attempt all ones in the significand
-                    target = (1 << 2 * constants.MANTISSA_BITS[fmt] + 1) - 1
-                    factors = cached_factorint(target)
-                    f1, f2 = factors_to_bit_width(factors, target, constants.MANTISSA_BITS[fmt] + 1)
+                    sigA, sigB = attempted_sigs
+                    exp_diff = shift_amount
 
-                    if f1 * f2 == target:
-                        sigA, sigB = f1, f2
-                        one_location = 2 * constants.MANTISSA_BITS[fmt]  # After the decimal point
-                    else:
-                        sigA = (1 << constants.MANTISSA_BITS[fmt] + 1) - 2
-                        sigB = (1 << constants.MANTISSA_BITS[fmt]) + 1
-                        # These are the second best thing we can do
-                        one_location = 2 * constants.MANTISSA_BITS[fmt] - 1
+                # Randomized Exponents so that we get the desired exponent difference
+                prod_exp = random.randint(max(min_exp, min_exp - exp_diff), min(max_exp, max_exp - exp_diff))
+                add_exp = prod_exp + exp_diff
 
-                    exp_diff = target_placement - one_location + constants.MANTISSA_BITS[fmt] + 1
+                # Find two exponents that add to prod_exp
+                mul_exp1 = random.randint(max(min_exp, prod_exp - max_exp), min(max_exp, prod_exp - min_exp))
+                mul_exp2 = prod_exp - mul_exp1
 
-                    if exp_diff > constants.MANTISSA_BITS[fmt]:
-                        continue
-            else:
-                sigA, sigB = attempted_sigs
-                exp_diff = shift_amount
+                # Order doesn't matter so randomly swap them
+                if random.random() < 0.5:
+                    mul_exp1, mul_exp2 = mul_exp2, mul_exp1
 
-            # Randomized Exponents so that we get the desired exponent difference
-            prod_exp = random.randint(max(min_exp, min_exp - exp_diff), min(max_exp, max_exp - exp_diff))
-            add_exp = prod_exp + exp_diff
+                if random.random() < 0.5:
+                    sigA, sigB = sigB, sigA
 
-            # Find two exponents that add to prod_exp
-            mul_exp1 = random.randint(max(min_exp, prod_exp - max_exp), min(max_exp, prod_exp - min_exp))
-            mul_exp2 = prod_exp - mul_exp1
+                sigC = random.getrandbits(constants.MANTISSA_BITS[fmt] - 1)  # -1 to stop all carry chains
+                if effective_subtraction:
+                    sigC |= 1 << (constants.MANTISSA_BITS[fmt] - 1)
+                    sigC |= 1 << (constants.MANTISSA_BITS[fmt] - 2)  # Stop all borrow chains
 
-            # Order doesn't matter so randomly swap them
-            if random.random() < 0.5:
-                mul_exp1, mul_exp2 = mul_exp2, mul_exp1
+                if exp_diff == 0:
+                    add_exp -= 2
+                    sigC &= ~0b11
+                elif (sigA * sigB).bit_length() == (2 * constants.MANTISSA_BITS[fmt] + 2):
+                    pass
 
-            if random.random() < 0.5:
-                sigA, sigB = sigB, sigA
+                signA = random.randint(0, 1)
+                signB = signA
+                if op == constants.OP_FNMADD or op == constants.OP_FNMSUB:
+                    signB ^= 1
 
-            sigC = random.getrandbits(constants.MANTISSA_BITS[fmt] - 1)  # -1 to stop all carry chains
-            if effective_subtraction:
-                sigC |= 1 << (constants.MANTISSA_BITS[fmt] - 1)
-                sigC |= 1 << (constants.MANTISSA_BITS[fmt] - 2)  # Stop all borrow chains
+                signC = 0
 
-            if exp_diff == 0:
-                add_exp -= 2
-                sigC &= ~0b11
-            elif (sigA * sigB).bit_length() == (2 * constants.MANTISSA_BITS[fmt] + 2):
-                pass
+                floatA = generate_float(signA, mul_exp1, sigA ^ (1 << constants.MANTISSA_BITS[fmt]), fmt)
+                floatB = generate_float(signB, mul_exp2, sigB ^ (1 << constants.MANTISSA_BITS[fmt]), fmt)
+                floatC = generate_float(signC, add_exp, sigC, fmt)
 
-            signA = random.randint(0, 1)
-            signB = signA
-            if op == constants.OP_FNMADD or op == constants.OP_FNMSUB:
-                signB ^= 1
+                tv = generate_test_vector(op, floatA, floatB, floatC, fmt, fmt, constants.ROUND_MAX)
+                result = run_test_vector(tv)
 
-            signC = 0
+                interm_mantissa = bin(int("1" + result.split("_")[-2], 16))[3:]
+                actual_extra_bits = interm_mantissa[constants.MANTISSA_BITS[fmt] :]
+                placement = actual_extra_bits.rfind("1")
 
-            floatA = generate_float(signA, mul_exp1, sigA ^ (1 << constants.MANTISSA_BITS[fmt]), fmt)
-            floatB = generate_float(signB, mul_exp2, sigB ^ (1 << constants.MANTISSA_BITS[fmt]), fmt)
-            floatC = generate_float(signC, add_exp, sigC, fmt)
-
-            tv = generate_test_vector(op, floatA, floatB, floatC, fmt, fmt, constants.ROUND_MAX)
-            result = run_test_vector(tv)
-
-            interm_mantissa = bin(int("1" + result.split("_")[-2], 16))[3:]
-            actual_extra_bits = interm_mantissa[constants.MANTISSA_BITS[fmt] :]
-            placement = actual_extra_bits.rfind("1")
-
-            if (placement != target_placement) or actual_extra_bits.count("1") != 1:
-                log_error(f"Failed To Generate C +- Prod Cases for FMA, op={op}, target={target_placement}")
-                continue
-            elif placement not in placements:
-                placements.append(placement)
-                store_cover_vector(result, test_f, cover_f)
+                if (placement != target_placement) or actual_extra_bits.count("1") != 1:
+                    logger.exception(f"Failed To Generate C +- Prod Cases for FMA, op={op}, target={target_placement}")
+                    continue
+                elif placement not in placements:
+                    placements.append(placement)
+                    store_cover_vector(result, test_f, cover_f)
 
 
 def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -628,7 +630,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             elif fmt == "04" and constants.MANTISSA_BITS[fmt] + extra_bit >= 23:
                 store_cover_vector(result, test_f, cover_f)  # This is just a quirk of how bf16 converts work
             else:
-                log_error(f"CFF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bits: {extra_bits:b}")
+                logger.exception(f"CFF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bits: {extra_bits:b}")
 
     # CFI
     for to_fmt in constants.INT_FMTS:
@@ -696,7 +698,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             ):
                 store_cover_vector(result, test_f, cover_f)  # Softfloat quirk makes it not track correctly here
             else:
-                log_error(f"CIF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bit: {extra_bit}")
+                logger.exception(f"CIF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bit: {extra_bit}")
 
 
 @register_model("B7")

--- a/src/cover_float/testgen/B7.py
+++ b/src/cover_float/testgen/B7.py
@@ -10,10 +10,10 @@
 
 import functools
 import random
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional, TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.log import log_error, progress_bar
 from cover_float.common.util import (
     bezout_inverse,
     factors_to_bit_width,
@@ -22,6 +22,7 @@ from cover_float.common.util import (
     reproducible_hash,
 )
 from cover_float.reference import run_test_vector, store_cover_vector
+from cover_float.testgen.model import register_model
 
 if TYPE_CHECKING:
     # This block is seen by Pyright but ignored at runtime
@@ -79,7 +80,7 @@ def add_sub_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             rounding_bits = rounding_bits[:nf]
 
             if int(rounding_bits, 2) != 1 << (nf - extra_bit - 1):
-                print(f"Add Sub Generation Failed: extra_bit: {extra_bit}, op: {op}")
+                log_error(f"Add Sub Generation Failed: extra_bit: {extra_bit}, op: {op}")
             else:
                 store_cover_vector(result, test_f, cover_f)
 
@@ -171,8 +172,8 @@ def mul_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             if hit_with_shift and hit_without_shift:
                 break
         else:
-            print(
-                f"Failure to generate mul tests :(, fmt={fmt}, extra_bit={extra_bit}, hit_with_shift={hit_with_shift}, "
+            log_error(
+                f"Failure to generate mul tests, fmt={fmt}, extra_bit={extra_bit}, hit_with_shift={hit_with_shift}, "
                 f"hit_without_shift={hit_without_shift}"
             )
 
@@ -416,9 +417,9 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                     store_cover_vector(result, test_f, cover_f)
                     break
                 if actual_extra_bits[1:] == expected_extra_bits[1:]:
-                    print("Failure in FMA Test Generation, failed to create the expected bits")
+                    log_error("Failure in FMA Test Generation, failed to create the expected bits")
             else:
-                print("Failure to generate a Guard=0 Case in FMA Testgen")
+                log_error("Failure to generate a Guard=0 Case in FMA Testgen")
 
         # Now do the addend hanging off of the end of the mantissa
         # This will be the (2nf + 1)th extra bit
@@ -477,7 +478,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                     store_cover_vector(result, test_f, cover_f)
                     break
             else:
-                print(
+                log_error(
                     f"Failure to generate big multiplication, small, far addend for fma with sticky = {overhang_extra}"
                     f" in fmt: {fmt}"
                 )
@@ -494,16 +495,12 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         # the leading one from the multiplication mantissa is in the lsb
         placements: list[int] = []
 
-        for target_placement in range(1, 2 * constants.MANTISSA_BITS[fmt]):
+        for target_placement in progress_bar(
+            range(1, 2 * constants.MANTISSA_BITS[fmt]), desc=f"{fmt} FMA Target Placements", miniters=1
+        ):
             # if target_placement > STICKY_LIMITS.get(fmt, 1000):
             #     # The things that are possible within what softfloat gives us
             #     break
-
-            print(
-                f"{fmt} target_placement: {target_placement}/"
-                f"{STICKY_LIMITS.get(fmt, 2 * constants.MANTISSA_BITS[fmt])}",
-                end="\r",
-            )
 
             # We want the lowest possible exponent difference
             shift_amount = max(3, target_placement - constants.MANTISSA_BITS[fmt] + 1)
@@ -525,7 +522,6 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                         exp_diff = target_placement - lowest_one + constants.MANTISSA_BITS[fmt] + 1
 
                         if exp_diff > constants.MANTISSA_BITS[fmt]:
-                            # print("attempted sigs failed, no recourse :(")
                             continue
                 else:
                     # 1st attempt all ones in the significand
@@ -595,13 +591,11 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             placement = actual_extra_bits.rfind("1")
 
             if (placement != target_placement) or actual_extra_bits.count("1") != 1:
-                print(f"B7: Failed To Generate C +- Prod Cases for FMA, op={op}, target={target_placement}")
+                log_error(f"Failed To Generate C +- Prod Cases for FMA, op={op}, target={target_placement}")
                 continue
             elif placement not in placements:
                 placements.append(placement)
                 store_cover_vector(result, test_f, cover_f)
-
-        print("\x1b[2K", end="\r")
 
 
 def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -634,7 +628,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             elif fmt == "04" and constants.MANTISSA_BITS[fmt] + extra_bit >= 23:
                 store_cover_vector(result, test_f, cover_f)  # This is just a quirk of how bf16 converts work
             else:
-                print(f"CFF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bits: {extra_bits:b}")
+                log_error(f"CFF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bits: {extra_bits:b}")
 
     # CFI
     for to_fmt in constants.INT_FMTS:
@@ -702,22 +696,13 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             ):
                 store_cover_vector(result, test_f, cover_f)  # Softfloat quirk makes it not track correctly here
             else:
-                print(f"CIF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bit: {extra_bit}")
+                log_error(f"CIF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bit: {extra_bit}")
 
 
-def main() -> None:
-    print("Running B7")
-
-    with (
-        Path("tests/testvectors/B7_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B7_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            add_sub_tests(fmt, test_f, cover_f)
-            mul_tests(fmt, test_f, cover_f)
-            fma_tests(fmt, test_f, cover_f)
-            convert_tests(fmt, test_f, cover_f)
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B7")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        add_sub_tests(fmt, test_f, cover_f)
+        mul_tests(fmt, test_f, cover_f)
+        fma_tests(fmt, test_f, cover_f)
+        convert_tests(fmt, test_f, cover_f)

--- a/src/cover_float/testgen/B7.py
+++ b/src/cover_float/testgen/B7.py
@@ -660,7 +660,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             if rounding_bits == bin(frac_part)[2:].zfill(frac_bits):
                 store_cover_vector(result, test_f, cover_f)
             else:
-                print(f"CFI Generation Failure From: {fmt}, To: {to_fmt}, Extra-Bits: {frac_part:b}")
+                logger.exception(f"CFI Generation Failure From: {fmt}, To: {to_fmt}, Extra-Bits: {frac_part:b}")
 
     # CIF
     for from_fmt in constants.INT_FMTS:

--- a/src/cover_float/testgen/B8.py
+++ b/src/cover_float/testgen/B8.py
@@ -1,11 +1,12 @@
 # B8 (rwolk@hmc.edu)
 
 import itertools
+import logging
 import random
-from typing import Optional, TextIO
+from typing import Optional, TextIO, cast
 
 import cover_float.common.constants as constants
-from cover_float.common.log import log_error
+import cover_float.common.log as log
 from cover_float.common.util import (
     bezout_inverse,
     extract_rounding_info,
@@ -16,6 +17,8 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_and_store_test_vector, run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
+
+logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B8"))
 
 
 def mul_sigs_with_trailing(target: int, bit_length: int, fmt: str) -> tuple[int, int]:
@@ -138,7 +141,7 @@ def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, targe
         for sign, lsb, guard in sign_lsb_guard():
             maybe_result = divideSetRounding(lsb, guard, target, target_bits, fmt)
             if not maybe_result:
-                log_error(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
+                logger.exception(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
                 continue
 
             s1, s2 = maybe_result
@@ -157,14 +160,14 @@ def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, targe
             if check_div_result(result, target, target_bits) and info["Guard"] == guard and info["LSB"] == lsb:
                 store_cover_vector(result, test_f, cover_f)
             else:
-                log_error(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
+                logger.exception(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
 
     for target_offset in range(4, 0, -1):
         target = (1 << target_bits) - target_offset
         for sign, lsb, guard in sign_lsb_guard():
             maybe_result = divideSetRounding(lsb, guard, target, target_bits, fmt)
             if not maybe_result:
-                log_error(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
+                logger.exception(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
                 continue
 
             s1, s2 = maybe_result
@@ -183,7 +186,7 @@ def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, targe
             if check_div_result(result, target, target_bits) and info["Guard"] == guard and info["LSB"] == lsb:
                 store_cover_vector(result, test_f, cover_f)
             else:
-                log_error(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
+                logger.exception(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
 
 
 def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -218,7 +221,9 @@ def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                 run_and_store_test_vector(tv, test_f, cover_f)
                 break
             else:
-                log_error(f"Mul Generation Failed: fmt={fmt}, lsb={lsb}, guard={guard}, extra_bits={target_sticky}")
+                logger.exception(
+                    f"Mul Generation Failed: fmt={fmt}, lsb={lsb}, guard={guard}, extra_bits={target_sticky}"
+                )
 
 
 def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -292,7 +297,7 @@ def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 ):
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    log_error(
+                    logger.exception(
                         f"Add/Sub Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb}, "
                         f"extra_bits:{target_sticky}"
                     )
@@ -381,7 +386,7 @@ def generate_fma_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                         store_cover_vector(result, test_f, cover_f)
                         break
                     else:
-                        log_error(
+                        logger.exception(
                             f"FMA Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb},"
                             f" extra_bits:{sticky_target}"
                         )
@@ -440,7 +445,7 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 ) or (fmt == constants.FMT_QUAD and target_fmt == constants.FMT_BF16):
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    log_error(
+                    logger.exception(
                         f"CFF/CFI Generation Failed, fmt={fmt}, target_fmt={target_fmt}, lsb={lsb}, guard={guard}, "
                         f"extra_bits={extra_bits:b}"
                     )
@@ -480,7 +485,7 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 ) or fmt == constants.FMT_BF16:
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    log_error(
+                    logger.exception(
                         f"CIF Generation Failed, from_fmt={from_fmt}, fmt={fmt}, lsb={lsb}, guard={guard}, "
                         f"extra_bits={extra_bits:b}"
                     )

--- a/src/cover_float/testgen/B8.py
+++ b/src/cover_float/testgen/B8.py
@@ -2,10 +2,10 @@
 
 import itertools
 import random
-from pathlib import Path
 from typing import Optional, TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.log import log_error
 from cover_float.common.util import (
     bezout_inverse,
     extract_rounding_info,
@@ -15,8 +15,7 @@ from cover_float.common.util import (
     unpack_test_vector,
 )
 from cover_float.reference import run_and_store_test_vector, run_test_vector, store_cover_vector
-
-# Test Plan: Add/Sub (effective ops), Mul, FMA (effective ops), DIV, SQRT, then Converts are easy
+from cover_float.testgen.model import register_model
 
 
 def mul_sigs_with_trailing(target: int, bit_length: int, fmt: str) -> tuple[int, int]:
@@ -139,7 +138,7 @@ def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, targe
         for sign, lsb, guard in sign_lsb_guard():
             maybe_result = divideSetRounding(lsb, guard, target, target_bits, fmt)
             if not maybe_result:
-                print(f"Failure for lsb={lsb}, guard={guard}, sticky={target:b}")
+                log_error(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
                 continue
 
             s1, s2 = maybe_result
@@ -158,14 +157,14 @@ def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, targe
             if check_div_result(result, target, target_bits) and info["Guard"] == guard and info["LSB"] == lsb:
                 store_cover_vector(result, test_f, cover_f)
             else:
-                print("Div Result Failure")
+                log_error(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
 
     for target_offset in range(4, 0, -1):
         target = (1 << target_bits) - target_offset
         for sign, lsb, guard in sign_lsb_guard():
             maybe_result = divideSetRounding(lsb, guard, target, target_bits, fmt)
             if not maybe_result:
-                print(f"Failure for lsb={lsb}, guard={guard}, sticky={target:b}")
+                log_error(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
                 continue
 
             s1, s2 = maybe_result
@@ -184,7 +183,7 @@ def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, targe
             if check_div_result(result, target, target_bits) and info["Guard"] == guard and info["LSB"] == lsb:
                 store_cover_vector(result, test_f, cover_f)
             else:
-                print("Div Result Failure")
+                log_error(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
 
 
 def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -219,7 +218,7 @@ def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                 run_and_store_test_vector(tv, test_f, cover_f)
                 break
             else:
-                print(f"B8 Mul Generation Failed: fmt={fmt}, lsb={lsb}, guard={guard}, extra_bits={target_sticky}")
+                log_error(f"Mul Generation Failed: fmt={fmt}, lsb={lsb}, guard={guard}, extra_bits={target_sticky}")
 
 
 def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
@@ -293,8 +292,8 @@ def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 ):
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    print(
-                        f"B8 Add/Sub Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb}, "
+                    log_error(
+                        f"Add/Sub Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb}, "
                         f"extra_bits:{target_sticky}"
                     )
 
@@ -382,8 +381,8 @@ def generate_fma_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                         store_cover_vector(result, test_f, cover_f)
                         break
                     else:
-                        print(
-                            f"B8 FMA Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb},"
+                        log_error(
+                            f"FMA Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb},"
                             f" extra_bits:{sticky_target}"
                         )
 
@@ -441,8 +440,8 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 ) or (fmt == constants.FMT_QUAD and target_fmt == constants.FMT_BF16):
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    print(
-                        f"B8 CFF/CFI Generation Failed, fmt={fmt}, target_fmt={target_fmt}, lsb={lsb}, guard={guard}, "
+                    log_error(
+                        f"CFF/CFI Generation Failed, fmt={fmt}, target_fmt={target_fmt}, lsb={lsb}, guard={guard}, "
                         f"extra_bits={extra_bits:b}"
                     )
 
@@ -481,26 +480,18 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 ) or fmt == constants.FMT_BF16:
                     store_cover_vector(result, test_f, cover_f)
                 else:
-                    print(
-                        f"B8 CIF Generation Failed, from_fmt={from_fmt}, fmt={fmt}, lsb={lsb}, guard={guard}, "
+                    log_error(
+                        f"CIF Generation Failed, from_fmt={from_fmt}, fmt={fmt}, lsb={lsb}, guard={guard}, "
                         f"extra_bits={extra_bits:b}"
                     )
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B8_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B8_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            for rm in constants.ROUNDING_MODES:
-                generate_div_tests(fmt, rm, test_f, cover_f)
-                generate_mul_tests(fmt, rm, test_f, cover_f)
-                generate_add_sub_tests(fmt, rm, test_f, cover_f)
-                generate_fma_tests(fmt, rm, test_f, cover_f)
-                generate_convert_tests(fmt, rm, test_f, cover_f)
-        print("B8 Generated :)")
-
-
-if __name__ == "__main__":
-    main()
+@register_model("B8")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        for rm in constants.ROUNDING_MODES:
+            generate_div_tests(fmt, rm, test_f, cover_f)
+            generate_mul_tests(fmt, rm, test_f, cover_f)
+            generate_add_sub_tests(fmt, rm, test_f, cover_f)
+            generate_fma_tests(fmt, rm, test_f, cover_f)
+            generate_convert_tests(fmt, rm, test_f, cover_f)

--- a/src/cover_float/testgen/B9.py
+++ b/src/cover_float/testgen/B9.py
@@ -8,6 +8,7 @@ from typing import TextIO
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
+from cover_float.testgen.model import register_model
 
 B9_1SRC = [constants.OP_SQRT]
 B9_2SRC = [
@@ -205,23 +206,20 @@ def B9_generator(sigs: list[str], fmt: str, test_f: TextIO, cover_f: TextIO) -> 
                     break  # Don't over generate tests
 
 
-def main() -> None:
-    with (
-        Path("tests/testvectors/B9_tv.txt").open("w") as test_f,
-        Path("tests/covervectors/B9_cv.txt").open("w") as cover_f,
-    ):
-        for fmt in constants.FLOAT_FMTS:
-            generator = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b9")
+@register_model("B9")
+def main(test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt in constants.FLOAT_FMTS:
+        generator = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b9")
 
-            bins_path = Path(
-                "coverage",
-                "covergroups",
-                "bins_templates",
-                "generated",
-                f"B9_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh",
-            )
-            bins_path.parent.mkdir(parents=True, exist_ok=True)
+        bins_path = Path(
+            "coverage",
+            "covergroups",
+            "bins_templates",
+            "generated",
+            f"B9_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh",
+        )
+        bins_path.parent.mkdir(parents=True, exist_ok=True)
 
-            with bins_path.open("w") as generated_coverage:
-                sigs = generator.generate(generated_coverage)
-                B9_generator(sigs, fmt, test_f, cover_f)
+        with bins_path.open("w") as generated_coverage:
+            sigs = generator.generate(generated_coverage)
+            B9_generator(sigs, fmt, test_f, cover_f)

--- a/src/cover_float/testgen/__init__.py
+++ b/src/cover_float/testgen/__init__.py
@@ -17,6 +17,7 @@ import cover_float.testgen.B25 as B25
 import cover_float.testgen.B26 as B26
 import cover_float.testgen.B27 as B27
 import cover_float.testgen.B29 as B29
+import cover_float.testgen.model as model
 
 __all__ = [
     "B1",
@@ -38,4 +39,5 @@ __all__ = [
     "B26",
     "B27",
     "B29",
+    "model",
 ]

--- a/src/cover_float/testgen/model.py
+++ b/src/cover_float/testgen/model.py
@@ -1,32 +1,35 @@
-import traceback
+import logging
 from pathlib import Path
 from typing import Callable, TextIO
 
 import cover_float.common.log as log
 from cover_float.scripts.parse_testvectors import auto_parse
 
-GLOBAL_MODELS: dict[str, Callable[[Path], None]] = {}
+GLOBAL_MODELS: dict[str, Callable[[Path, log.StatusReporter], None]] = {}
 
 
-def register_model(model_name: str) -> Callable[[Callable[[TextIO, TextIO], None]], Callable[[Path], None]]:
-    def inner(fn: Callable[[TextIO, TextIO], None]) -> Callable[[Path], None]:
-        def wrapper(output_dir: Path, post_process: bool = True) -> None:
+def register_model(
+    model_name: str,
+) -> Callable[[Callable[[TextIO, TextIO], None]], Callable[[Path, log.StatusReporter], None]]:
+    def inner(fn: Callable[[TextIO, TextIO], None]) -> Callable[[Path, log.StatusReporter], None]:
+        def wrapper(output_dir: Path, status_reporter: log.StatusReporter, post_process: bool = True) -> None:
             tv_path = output_dir / "testvectors" / f"{model_name}_tv.txt"
             cv_path = output_dir / "covervectors" / f"{model_name}_cv.txt"
 
-            log.set_prefix(f"{model_name} Test Generation: ")
+            status_reporter.start_model(model_name)
 
             with tv_path.open("w") as test_f, cv_path.open("w") as cover_f:
                 try:
                     fn(test_f, cover_f)
-                except Exception:
-                    print(f"\033[KFatal Error in {model_name}")
-                    traceback.print_exc()
+                except Exception as e:
+                    logger = logging.getLogger(model_name)
 
-            log.set_prefix(f"{model_name} Post Processing: ")
+                    logger.exception(f"[bold red]Fatal Error in {model_name}[/] ", exc_info=e, extra={"markup": True})
 
             if post_process:
                 auto_parse(model_name, str(output_dir))
+
+            status_reporter.stop_model(model_name)
 
         GLOBAL_MODELS[model_name] = wrapper
         return wrapper

--- a/src/cover_float/testgen/model.py
+++ b/src/cover_float/testgen/model.py
@@ -1,35 +1,115 @@
+import concurrent.futures
 import logging
+import logging.handlers
 from pathlib import Path
-from typing import Callable, TextIO
+from queue import Queue
+from typing import Any, Callable, TextIO
+
+from rich.progress import TaskID
 
 import cover_float.common.log as log
 from cover_float.scripts.parse_testvectors import auto_parse
 
-GLOBAL_MODELS: dict[str, Callable[[Path, log.StatusReporter], None]] = {}
+GLOBAL_MODELS: dict[
+    str, Callable[[Path, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[None]]
+] = {}
+GLOBAL_MODEL_FUNCTIONS: dict[str, Callable[[TextIO, TextIO], None]] = {}
+
+
+class MPLoggingHandler(logging.Handler):
+    def __init__(self, queue: Queue[Any], task_id: TaskID) -> None:
+        super().__init__()
+        self.queue = queue
+        self.task_id = task_id
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.queue.put(
+            {
+                "action": "update",
+                "args": [self.task_id],
+                "kwargs": {
+                    "status": record.msg,
+                },
+            }
+        )
+
+
+def _run_model_by_name(
+    model_name: str,
+    output_dir: Path,
+    task_id: TaskID,
+    progress_queue: Queue[Any],
+    logging_queue: Queue[Any],
+    post_process: bool,
+) -> None:
+    """Module-level function that can be pickled for multiprocessing."""
+    tv_path = output_dir / "testvectors" / f"{model_name}_tv.txt"
+    cv_path = output_dir / "covervectors" / f"{model_name}_cv.txt"
+
+    model_logger = logging.getLogger(model_name)
+
+    if isinstance(model_logger, log.ModelLogger):
+        model_logger.task_id = task_id
+        model_logger.msg_queue = progress_queue
+    else:
+        raise ValueError()
+
+    model_logger.handlers = []
+    model_logger.propagate = False
+
+    # Handle Status Updates
+    handler = MPLoggingHandler(progress_queue, task_id)
+    handler.addFilter(log.OnlyStatusFilter())
+    model_logger.addHandler(handler)
+
+    # Handle Other Updates
+    # general_handler = RichHandler()
+    general_handler = logging.handlers.QueueHandler(logging_queue)
+    general_handler.addFilter(log.ExcludeStatusFilter())
+    model_logger.addHandler(general_handler)
+
+    with tv_path.open("w") as test_f, cv_path.open("w") as cover_f:
+        try:
+            GLOBAL_MODEL_FUNCTIONS[model_name](test_f, cover_f)
+        except Exception as e:
+            logger = logging.getLogger(model_name)
+            logger.exception(f"[bold red]Fatal Error in {model_name}[/] ", exc_info=e, extra={"markup": True})
+
+    if post_process:
+        auto_parse(model_name, str(output_dir))
 
 
 def register_model(
     model_name: str,
-) -> Callable[[Callable[[TextIO, TextIO], None]], Callable[[Path, log.StatusReporter], None]]:
-    def inner(fn: Callable[[TextIO, TextIO], None]) -> Callable[[Path, log.StatusReporter], None]:
-        def wrapper(output_dir: Path, status_reporter: log.StatusReporter, post_process: bool = True) -> None:
-            tv_path = output_dir / "testvectors" / f"{model_name}_tv.txt"
-            cv_path = output_dir / "covervectors" / f"{model_name}_cv.txt"
+) -> Callable[
+    [Callable[[TextIO, TextIO], None]],
+    Callable[[Path, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[None]],
+]:
+    def inner(
+        fn: Callable[[TextIO, TextIO], None],
+    ) -> Callable[[Path, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[None]]:
+        # Store the function in a global dict so it can be accessed by the worker process
+        GLOBAL_MODEL_FUNCTIONS[model_name] = fn
 
-            status_reporter.start_model(model_name)
+        def wrapper(
+            output_dir: Path,
+            status_reporter: log.StatusReporter,
+            executor: concurrent.futures.Executor,
+            post_process: bool = True,
+        ) -> concurrent.futures.Future[None]:
+            task_id = status_reporter.start_model(model_name)
 
-            with tv_path.open("w") as test_f, cv_path.open("w") as cover_f:
-                try:
-                    fn(test_f, cover_f)
-                except Exception as e:
-                    logger = logging.getLogger(model_name)
-
-                    logger.exception(f"[bold red]Fatal Error in {model_name}[/] ", exc_info=e, extra={"markup": True})
-
-            if post_process:
-                auto_parse(model_name, str(output_dir))
-
-            status_reporter.stop_model(model_name)
+            future = executor.submit(
+                _run_model_by_name,
+                model_name,
+                output_dir,
+                task_id,
+                status_reporter.progress_queue,
+                status_reporter.logging_queue,
+                post_process,
+            )
+            future.add_done_callback(lambda _: status_reporter.stop_model(model_name))
+            return future
 
         GLOBAL_MODELS[model_name] = wrapper
         return wrapper

--- a/src/cover_float/testgen/model.py
+++ b/src/cover_float/testgen/model.py
@@ -41,7 +41,6 @@ def _run_model_by_name(
     logging_queue: Queue[Any],
     post_process: bool,
 ) -> None:
-    """Module-level function that can be pickled for multiprocessing."""
     tv_path = output_dir / "testvectors" / f"{model_name}_tv.txt"
     cv_path = output_dir / "covervectors" / f"{model_name}_cv.txt"
 
@@ -60,7 +59,6 @@ def _run_model_by_name(
     model_logger.addHandler(handler)
 
     # Handle Other Updates
-    # general_handler = RichHandler()
     general_handler = logging.handlers.QueueHandler(logging_queue)
     general_handler.addFilter(log.ExcludeStatusFilter())
     model_logger.addHandler(general_handler)

--- a/src/cover_float/testgen/model.py
+++ b/src/cover_float/testgen/model.py
@@ -38,7 +38,6 @@ def _run_model_by_name(
     model_name: str,
     output_dir: Path,
     task_id: TaskID,
-    progress_queue: Queue[Any],
     logging_queue: Queue[Any],
     post_process: bool,
 ) -> None:
@@ -50,15 +49,13 @@ def _run_model_by_name(
 
     if isinstance(model_logger, log.ModelLogger):
         model_logger.task_id = task_id
-        model_logger.msg_queue = progress_queue
-    else:
-        raise ValueError()
+        model_logger.msg_queue = logging_queue
 
     model_logger.handlers = []
     model_logger.propagate = False
 
     # Handle Status Updates
-    handler = MPLoggingHandler(progress_queue, task_id)
+    handler = MPLoggingHandler(logging_queue, task_id)
     handler.addFilter(log.OnlyStatusFilter())
     model_logger.addHandler(handler)
 
@@ -104,7 +101,6 @@ def register_model(
                 model_name,
                 output_dir,
                 task_id,
-                status_reporter.progress_queue,
                 status_reporter.logging_queue,
                 post_process,
             )

--- a/src/cover_float/testgen/model.py
+++ b/src/cover_float/testgen/model.py
@@ -1,0 +1,34 @@
+import traceback
+from pathlib import Path
+from typing import Callable, TextIO
+
+import cover_float.common.log as log
+from cover_float.scripts.parse_testvectors import auto_parse
+
+GLOBAL_MODELS: dict[str, Callable[[Path], None]] = {}
+
+
+def register_model(model_name: str) -> Callable[[Callable[[TextIO, TextIO], None]], Callable[[Path], None]]:
+    def inner(fn: Callable[[TextIO, TextIO], None]) -> Callable[[Path], None]:
+        def wrapper(output_dir: Path, post_process: bool = True) -> None:
+            tv_path = output_dir / "testvectors" / f"{model_name}_tv.txt"
+            cv_path = output_dir / "covervectors" / f"{model_name}_cv.txt"
+
+            log.set_prefix(f"{model_name} Test Generation: ")
+
+            with tv_path.open("w") as test_f, cv_path.open("w") as cover_f:
+                try:
+                    fn(test_f, cover_f)
+                except Exception:
+                    print(f"\033[KFatal Error in {model_name}")
+                    traceback.print_exc()
+
+            log.set_prefix(f"{model_name} Post Processing: ")
+
+            if post_process:
+                auto_parse(model_name, str(output_dir))
+
+        GLOBAL_MODELS[model_name] = wrapper
+        return wrapper
+
+    return inner

--- a/uv.lock
+++ b/uv.lock
@@ -31,21 +31,12 @@ wheels = [
 ]
 
 [[package]]
-name = "colorama"
-version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
 name = "cover-float"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "rich" },
     { name = "sympy" },
-    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -57,8 +48,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "rich", specifier = "==14.1.0" },
     { name = "sympy", specifier = "==1.14.0" },
-    { name = "tqdm", specifier = "==4.67.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -126,6 +117,45 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -183,6 +213,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -272,6 +311,20 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -306,18 +359,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -31,11 +31,21 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "cover-float"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "sympy" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -46,7 +56,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "sympy", specifier = "==1.14.0" }]
+requires-dist = [
+    { name = "sympy", specifier = "==1.14.0" },
+    { name = "tqdm", specifier = "==4.67.3" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -293,6 +306,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I moved autoparse into the scripts folder (there will be more postprocessing logic coming soon), and I introduced a decorator for our tests so that the current method of adding things to cli.py can end. 

Logging was cleaned up across the board, and works through log_info and log_error now. This means that we can setup different levels of what people want to see / where information needs to go if necessary, and it keeps the status updates from longer running models into one line, which looks nicer. 

This also should address #76