### PR TITLE
B20, B26, and B27 Fixes to Coverage and Testgen

### DIFF
--- a/coverage/covergroups/B20.svh
+++ b/coverage/covergroups/B20.svh
@@ -31,36 +31,36 @@ covergroup B20_cg (virtual coverfloat_interface CFI);
     }
 
     F16_trailing_zeros: coverpoint
-    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-2 : INTERM_M_BITS-F16_M_BITS - 1], F16_M_BITS) //nf-bit mantissa window (leading 1 excluded)
-    iff (CFI.operandFmt == FMT_HALF && CFI.intermM[INTERM_M_BITS-F16_M_BITS-2 : 0] == '0) {   //gated to F16; guard+sticky region = all zero
+    count_trailing_zeros(CFI.intermM[INTERM_M_BITS - 1 : INTERM_M_BITS-F16_M_BITS], F16_M_BITS) //nf-bit mantissa window (leading 1 excluded)
+    iff (CFI.operandFmt == FMT_HALF && CFI.intermM[INTERM_M_BITS-F16_M_BITS-1 : 0] == '0) {   //gated to F16; guard+sticky region = all zero
         type_option.weight = 0;
         bins tz[] = {[0 : F16_M_BITS]}; //tz[nf] = mantissa all zero (fully exact)
     }
 
     F32_trailing_zeros: coverpoint
-    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-2 : INTERM_M_BITS-F32_M_BITS-1], F32_M_BITS)
-    iff (CFI.operandFmt == FMT_SINGLE && CFI.intermM[INTERM_M_BITS-F32_M_BITS-2 : 0] == '0) {
+    count_trailing_zeros(CFI.intermM[INTERM_M_BITS - 1 : INTERM_M_BITS-F32_M_BITS], F32_M_BITS)
+    iff (CFI.operandFmt == FMT_SINGLE && CFI.intermM[INTERM_M_BITS-F32_M_BITS-1 : 0] == '0) {
         type_option.weight = 0;
         bins tz[] = {[0 : F32_M_BITS]};
     }
 
     F64_trailing_zeros: coverpoint
-    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-2 : INTERM_M_BITS-F64_M_BITS-1], F64_M_BITS)
-    iff (CFI.operandFmt == FMT_DOUBLE && CFI.intermM[INTERM_M_BITS-F64_M_BITS-2 : 0] == '0) {
+    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-1 : INTERM_M_BITS-F64_M_BITS], F64_M_BITS)
+    iff (CFI.operandFmt == FMT_DOUBLE && CFI.intermM[INTERM_M_BITS-F64_M_BITS-1 : 0] == '0) {
         type_option.weight = 0;
         bins tz[] = {[0 : F64_M_BITS]};
     }
 
     F128_trailing_zeros: coverpoint
-    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-2 : INTERM_M_BITS-F128_M_BITS-1], F128_M_BITS)
-    iff (CFI.operandFmt == FMT_QUAD && CFI.intermM[INTERM_M_BITS-F128_M_BITS-2 : 0] == '0) {
+    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-1 : INTERM_M_BITS-F128_M_BITS], F128_M_BITS)
+    iff (CFI.operandFmt == FMT_QUAD && CFI.intermM[INTERM_M_BITS-F128_M_BITS-1 : 0] == '0) {
         type_option.weight = 0;
         bins tz[] = {[0 : F128_M_BITS]};
     }
 
     BF16_trailing_zeros: coverpoint
-    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-2 : INTERM_M_BITS-BF16_M_BITS-1], BF16_M_BITS)
-    iff (CFI.operandFmt == FMT_BF16 && CFI.intermM[INTERM_M_BITS-BF16_M_BITS-2 : 0] == '0) {
+    count_trailing_zeros(CFI.intermM[INTERM_M_BITS-1 : INTERM_M_BITS-BF16_M_BITS], BF16_M_BITS)
+    iff (CFI.operandFmt == FMT_BF16 && CFI.intermM[INTERM_M_BITS-BF16_M_BITS-1 : 0] == '0) {
         type_option.weight = 0;
         bins tz[] = {[0 : BF16_M_BITS]};
     }

--- a/coverage/covergroups/B27.svh
+++ b/coverage/covergroups/B27.svh
@@ -190,68 +190,151 @@ covergroup B27_cg (virtual coverfloat_interface CFI);
         }
 
     // ---------------------------------------------------------------
+    // Per-conversion Rest of Bits Data
+    // rest of bits = the (remaining bits) MSB fraction bits beyond the destination's precision
+    // ---------------------------------------------------------------
+
+    // F16 -> BF16
+    F16_to_BF16_remaining: coverpoint (CFI.a[F16_M_UPPER - BF16_M_BITS: 0] == '0)
+        iff (CFI.operandFmt == FMT_HALF && CFI.resultFmt == FMT_BF16
+             && CFI.a[F16_E_UPPER:F16_E_LOWER] == '1 && CFI.a[F16_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+
+    // F32 -> F16 / BF16
+    F32_to_F16_remaining: coverpoint (CFI.a[F32_M_UPPER - F16_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_SINGLE && CFI.resultFmt == FMT_HALF
+             && CFI.a[F32_E_UPPER:F32_E_LOWER] == '1 && CFI.a[F32_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+    F32_to_BF16_remaining: coverpoint (CFI.a[F32_M_UPPER - BF16_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_SINGLE && CFI.resultFmt == FMT_BF16
+             && CFI.a[F32_E_UPPER:F32_E_LOWER] == '1 && CFI.a[F32_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+
+    // F64 -> F32 / F16 / BF16
+    F64_to_F32_remaining: coverpoint (CFI.a[F64_M_UPPER - F32_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_DOUBLE && CFI.resultFmt == FMT_SINGLE
+             && CFI.a[F64_E_UPPER:F64_E_LOWER] == '1 && CFI.a[F64_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+    F64_to_F16_remaining: coverpoint (CFI.a[F64_M_UPPER - F16_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_DOUBLE && CFI.resultFmt == FMT_HALF
+             && CFI.a[F64_E_UPPER:F64_E_LOWER] == '1 && CFI.a[F64_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+    F64_to_BF16_remaining: coverpoint (CFI.a[F64_M_UPPER - BF16_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_DOUBLE && CFI.resultFmt == FMT_BF16
+             && CFI.a[F64_E_UPPER:F64_E_LOWER] == '1 && CFI.a[F64_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+
+    // F128 -> F64 / F32 / F16 / BF16
+    F128_to_F64_remaining: coverpoint (CFI.a[F128_M_UPPER - F64_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_QUAD && CFI.resultFmt == FMT_DOUBLE
+             && CFI.a[F128_E_UPPER:F128_E_LOWER] == '1 && CFI.a[F128_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+    F128_to_F32_remaining: coverpoint (CFI.a[F128_M_UPPER - F32_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_QUAD && CFI.resultFmt == FMT_SINGLE
+             && CFI.a[F128_E_UPPER:F128_E_LOWER] == '1 && CFI.a[F128_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+    F128_to_F16_remaining: coverpoint (CFI.a[F128_M_UPPER - F16_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_QUAD && CFI.resultFmt == FMT_HALF
+             && CFI.a[F128_E_UPPER:F128_E_LOWER] == '1 && CFI.a[F128_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+    F128_to_BF16_remaining: coverpoint (CFI.a[F128_M_UPPER - BF16_M_BITS : 0] == '0)
+        iff (CFI.operandFmt == FMT_QUAD && CFI.resultFmt == FMT_BF16
+             && CFI.a[F128_E_UPPER:F128_E_LOWER] == '1 && CFI.a[F128_M_UPPER:0] != 0) {
+            type_option.weight = 0;
+            bins all_zero = {1};
+            bins not_zero = {0};
+        }
+
+    // ---------------------------------------------------------------
     // Crosses (one per narrowing conversion)
     // sNaN + all-zero surviving payload == +-Inf, so it is ignored.
     // ---------------------------------------------------------------
 
     `ifdef COVER_F16
         `ifdef COVER_BF16
-            B27_F16_to_BF16: cross CFF_op, F16_nan_class, F16_to_BF16_surviving, F16_sign {
-                ignore_bins inf = binsof(F16_nan_class.snan) && binsof(F16_to_BF16_surviving.all_zero);
+            B27_F16_to_BF16: cross CFF_op, F16_nan_class, F16_to_BF16_surviving, F16_to_BF16_remaining, F16_sign {
+                ignore_bins inf = binsof(F16_nan_class.snan) && binsof(F16_to_BF16_surviving.all_zero) && binsof(F16_to_BF16_remaining.all_zero);
             }
         `endif
     `endif
 
     `ifdef COVER_F32
         `ifdef COVER_F16
-            B27_F32_to_F16: cross CFF_op, F32_nan_class, F32_to_F16_surviving, F32_sign {
-                ignore_bins inf = binsof(F32_nan_class.snan) && binsof(F32_to_F16_surviving.all_zero);
+            B27_F32_to_F16: cross CFF_op, F32_nan_class, F32_to_F16_surviving, F32_to_F16_remaining, F32_sign {
+                ignore_bins inf = binsof(F32_nan_class.snan) && binsof(F32_to_F16_surviving.all_zero) && binsof(F32_to_F16_remaining.all_zero);
             }
         `endif
         `ifdef COVER_BF16
-            B27_F32_to_BF16: cross CFF_op, F32_nan_class, F32_to_BF16_surviving, F32_sign {
-                ignore_bins inf = binsof(F32_nan_class.snan) && binsof(F32_to_BF16_surviving.all_zero);
+            B27_F32_to_BF16: cross CFF_op, F32_nan_class, F32_to_BF16_surviving, F32_to_BF16_remaining, F32_sign {
+                ignore_bins inf = binsof(F32_nan_class.snan) && binsof(F32_to_BF16_surviving.all_zero) && binsof(F32_to_BF16_remaining.all_zero);
             }
         `endif
     `endif
 
     `ifdef COVER_F64
         `ifdef COVER_F32
-            B27_F64_to_F32: cross CFF_op, F64_nan_class, F64_to_F32_surviving, F64_sign {
-                ignore_bins inf = binsof(F64_nan_class.snan) && binsof(F64_to_F32_surviving.all_zero);
+            B27_F64_to_F32: cross CFF_op, F64_nan_class, F64_to_F32_surviving, F64_to_F32_remaining, F64_sign {
+                ignore_bins inf = binsof(F64_nan_class.snan) && binsof(F64_to_F32_surviving.all_zero) && binsof(F64_to_F32_remaining.all_zero);
             }
         `endif
         `ifdef COVER_F16
-            B27_F64_to_F16: cross CFF_op, F64_nan_class, F64_to_F16_surviving, F64_sign {
-                ignore_bins inf = binsof(F64_nan_class.snan) && binsof(F64_to_F16_surviving.all_zero);
+            B27_F64_to_F16: cross CFF_op, F64_nan_class, F64_to_F16_surviving, F64_to_F16_remaining, F64_sign {
+                ignore_bins inf = binsof(F64_nan_class.snan) && binsof(F64_to_F16_surviving.all_zero) && binsof(F64_to_F16_remaining.all_zero);
             }
         `endif
         `ifdef COVER_BF16
-            B27_F64_to_BF16: cross CFF_op, F64_nan_class, F64_to_BF16_surviving, F64_sign {
-                ignore_bins inf = binsof(F64_nan_class.snan) && binsof(F64_to_BF16_surviving.all_zero);
+            B27_F64_to_BF16: cross CFF_op, F64_nan_class, F64_to_BF16_surviving, F64_to_BF16_remaining, F64_sign {
+                ignore_bins inf = binsof(F64_nan_class.snan) && binsof(F64_to_BF16_surviving.all_zero) && binsof(F64_to_BF16_remaining.all_zero);
             }
         `endif
     `endif
 
     `ifdef COVER_F128
         `ifdef COVER_F64
-            B27_F128_to_F64: cross CFF_op, F128_nan_class, F128_to_F64_surviving, F128_sign {
-                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_F64_surviving.all_zero);
+            B27_F128_to_F64: cross CFF_op, F128_nan_class, F128_to_F64_surviving, F128_to_F64_remaining, F128_sign {
+                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_F64_surviving.all_zero) && binsof(F128_to_F64_remaining.all_zero);
             }
         `endif
         `ifdef COVER_F32
-            B27_F128_to_F32: cross CFF_op, F128_nan_class, F128_to_F32_surviving, F128_sign {
-                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_F32_surviving.all_zero);
+            B27_F128_to_F32: cross CFF_op, F128_nan_class, F128_to_F32_surviving, F128_to_F32_remaining, F128_sign {
+                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_F32_surviving.all_zero) && binsof(F128_to_F32_remaining.all_zero);
             }
         `endif
         `ifdef COVER_F16
-            B27_F128_to_F16: cross CFF_op, F128_nan_class, F128_to_F16_surviving, F128_sign {
-                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_F16_surviving.all_zero);
+            B27_F128_to_F16: cross CFF_op, F128_nan_class, F128_to_F16_surviving, F128_to_F16_remaining, F128_sign {
+                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_F16_surviving.all_zero) && binsof(F128_to_F16_remaining.all_zero);
             }
         `endif
         `ifdef COVER_BF16
-            B27_F128_to_BF16: cross CFF_op, F128_nan_class, F128_to_BF16_surviving, F128_sign {
-                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_BF16_surviving.all_zero);
+            B27_F128_to_BF16: cross CFF_op, F128_nan_class, F128_to_BF16_surviving, F128_to_BF16_remaining, F128_sign {
+                ignore_bins inf = binsof(F128_nan_class.snan) && binsof(F128_to_BF16_surviving.all_zero) && binsof(F128_to_BF16_remaining.all_zero);
             }
         `endif
     `endif

--- a/src/cover_float/testgen/B26.py
+++ b/src/cover_float/testgen/B26.py
@@ -30,15 +30,15 @@ def generate_B26(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
     for float_fmt in constants.FLOAT_FMTS:
         seed = reproducible_hash(f"B26 {int_fmt} {float_fmt}")
         random.seed(seed)
-        for msb in range(bits):
-            unsigned = 1 << msb | random.getrandbits(msb)
+        for msb in range(-1, bits):
+            unsigned = 1 << msb | random.getrandbits(msb) if msb != -1 else 0
             tv = generate_test_vector(
                 constants.OP_CIF, unsigned, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
             )
             run_and_store_test_vector(tv, test_f, cover_f)
 
             if constants.INT_SIGNED[int_fmt]:
-                signed = -(1 << msb | random.getrandbits(msb))
+                signed = -(1 << msb | random.getrandbits(msb)) if msb != -1 else 0
                 unsigned = signed & (
                     (1 << constants.INT_SIZES[int_fmt]) - 1
                 )  # This gives a twos complement representation

--- a/src/cover_float/testgen/B27.py
+++ b/src/cover_float/testgen/B27.py
@@ -36,18 +36,25 @@ def generate_B27(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             # We only want narrowing conversions
             continue
 
-        for q_nan_bit, other_frac_bits, sign_bit in itertools.product([0, 1], repeat=3):
-            if q_nan_bit == 0 and other_frac_bits == 0:
+        for q_nan_bit, common_bits, rest_of_bits, sign_bit in itertools.product([0, 1], repeat=4):
+            if q_nan_bit == 0 and common_bits == 0 and rest_of_bits == 0:
                 continue  # This generates +- Inf
 
-            exp = (1 << constants.EXPONENT_BIAS[fmt]) - 1
+            exp = (1 << constants.EXPONENT_BITS[fmt]) - 1
             f = (sign_bit << constants.EXPONENT_BITS[fmt] | exp) << constants.MANTISSA_BITS[fmt]
             f |= q_nan_bit << constants.MANTISSA_BITS[fmt] - 1
 
-            if other_frac_bits:
-                bits = random.getrandbits(constants.MANTISSA_BITS[fmt] - 1)
+            rest_of_bits_count = constants.MANTISSA_BITS[fmt] - constants.MANTISSA_BITS[to_fmt]
+            if common_bits:
+                bits = random.getrandbits(constants.MANTISSA_BITS[to_fmt] - 1)
                 while bits == 0:  # Make it actually generate something non-zero
-                    bits = random.getrandbits(constants.MANTISSA_BITS[fmt] - 1)
+                    bits = random.getrandbits(constants.MANTISSA_BITS[to_fmt] - 1)
+                f |= bits << rest_of_bits_count
+
+            if rest_of_bits:
+                bits = random.getrandbits(rest_of_bits_count)
+                while bits == 0:
+                    bits = random.getrandbits(rest_of_bits_count - 1)
                 f |= bits
 
             tv = generate_test_vector(constants.OP_CFF, f, 0, 0, fmt, to_fmt)  # Rounding mode does not matter


### PR DESCRIPTION
Fixed: 
- B20 accounted for a leading one that is not present in the `intermM` field.
- B26 didn't generate test cases for the zero case
- Neither B27 testgen nor coverage properly accounted for all three parts of the cross (qNaN vs sNAN, the bits common to both formats, and the mantissa bits only in one format). This has been added to both testgen and coverage.

All of these models are now at 100% coverage. 