### PR TITLE
Fix IntMin Discrepancy between Testgen and Coverage

### DIFF
--- a/coverage/covergroups/B25.svh
+++ b/coverage/covergroups/B25.svh
@@ -53,10 +53,11 @@ covergroup B25_cg (virtual coverfloat_interface CFI);
         type_option.weight = 0;
         bins zero    = {0};
         bins pos_one = {1};
-        bins neg_one = {'1};                                  // 0xFFFF_FFFF = -1
-        bins pos_max = {{1'b0, {(SIZEOF_INT-1){1'b1}}}};      // 0x7FFF_FFFF =  MaxInt
-        bins neg_max = {{1'b1, {(SIZEOF_INT-2){1'b0}}, 1'b1}};// 0x8000_0001 = -MaxInt
-        bins random  = default;                              // "Random number"
+        bins neg_one = {'1};                                                   // 0xFFFF_FFFF = -1
+        bins pos_max = {{1'b0, {(SIZEOF_INT-1){1'b1}}}};                       // 0x7FFF_FFFF =  MaxInt
+        bins neg_int_max = {{1'b1, {(SIZEOF_INT-2){1'b0}}, 1'b1}};             // 0x8000_0001 = -MaxInt
+        bins neg_max = {{1'b1, {(SIZEOF_INT-1){1'b0}}}};                       // 0x8000_0000 =  NegMaxInt
+        bins random  = {[2:32'h7fff_ffff-1], [32'h8000_0002:32'hffff_ffff-1]}; // Catch-All for "Random number"
     }
 
     // 32-bit UNSIGNED input
@@ -65,7 +66,7 @@ covergroup B25_cg (virtual coverfloat_interface CFI);
         bins zero     = {0};
         bins one      = {1};
         bins max_uint = {'1};                                // 0xFFFF_FFFF = MaxUInt
-        bins random   = default;
+        bins random   = {[2:32'hffff_ffff-1]};
     }
 
     // 64-bit SIGNED input
@@ -75,8 +76,9 @@ covergroup B25_cg (virtual coverfloat_interface CFI);
         bins pos_one = {1};
         bins neg_one = {'1};
         bins pos_max = {{1'b0, {(SIZEOF_LONG-1){1'b1}}}};
-        bins neg_max = {{1'b1, {(SIZEOF_LONG-2){1'b0}}, 1'b1}};
-        bins random  = default;
+        bins neg_int_max = {{1'b1, {(SIZEOF_LONG-2){1'b0}}, 1'b1}};
+        bins neg_max = {{1'b1, {(SIZEOF_LONG-1){1'b0}}}};
+        bins random  = {[2:64'h7fff_ffff_ffff_ffff-1], [64'h8000_0000_0000_0002:64'hffff_ffff_ffff_ffff-1]};
     }
 
     // 64-bit UNSIGNED input
@@ -85,7 +87,7 @@ covergroup B25_cg (virtual coverfloat_interface CFI);
         bins zero     = {0};
         bins one      = {1};
         bins max_uint = {'1};
-        bins random   = default;
+        bins random   = {[2:64'hffff_ffff_ffff_ffff-1]};
     }
 
 

--- a/docs/B25.adoc
+++ b/docs/B25.adoc
@@ -27,7 +27,7 @@ This model creates a test-case for each of the following inputs:
 
 == Background
 
-These are simply the basic test cases for each possible input into a convert int to float operation.
+These are simply the basic test cases for each possible input into a convert int to float operation. In addition, we add IntMin for signed integer conversions.
 
 == Test Procedure
 
@@ -35,4 +35,4 @@ We generate a test for each value in the list that is achievable in the given fo
 
 == Test Count Breakdown
 
-Each signed integer type will generate 6 tests and each unsigned integer type generates 4 tests. Across all integer types there are 20 tests for each of the 5 floating point precision, giving 100 total tests.
+Each signed integer type will generate 7 tests and each unsigned integer type generates 4 tests. Across all integer types there are 22 tests for each of the 5 floating point precision, giving 110 total tests.

--- a/src/cover_float/testgen/B25.py
+++ b/src/cover_float/testgen/B25.py
@@ -49,6 +49,11 @@ def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         if constants.INT_SIGNED[int_fmt]:
             # - Max Int
             tv = generate_test_vector(
+                constants.OP_CIF, 1 << int_bits | 1, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
+            )
+            run_and_store_test_vector(tv, test_f, cover_f)
+            # IntMin (maximum negative int)
+            tv = generate_test_vector(
                 constants.OP_CIF, 1 << int_bits, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
             )
             run_and_store_test_vector(tv, test_f, cover_f)


### PR DESCRIPTION
This brings coverage to 100%.

The question is over interpreting -IntMax as the most negative integer, or just the negative max integer. I think its a little strange to have an edge test for integer conversion that doesn't use the most negative integer, so I decided to include both interpretations in both testgen and coverage. In addition, I changed the random bin to actually collect coverage now. 