### PR TITLE
B5 Coverage

### DIFF
--- a/coverage/covergroups/B5.svh
+++ b/coverage/covergroups/B5.svh
@@ -67,27 +67,6 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
         bins f128 = {1};
     }
 
-    int_result_fmt : coverpoint CFI.resultFmt == FMT_INT {
-        type_option.weight = 0;
-        // int format for result
-        bins fmt_int = {1};
-    }
-    uint_result_fmt : coverpoint CFI.resultFmt == FMT_UINT {
-        type_option.weight = 0;
-        // uint format for result
-        bins fmt_uint = {1};
-    }
-    long_result_fmt : coverpoint CFI.resultFmt == FMT_LONG {
-        type_option.weight = 0;
-        // long format for result
-        bins fmt_long = {1};
-    }
-    ulong_result_fmt : coverpoint CFI.resultFmt == FMT_ULONG {
-        type_option.weight = 0;
-        // ulong format for result
-        bins fmt_ulong = {1};
-    }
-
     FP_convert_ops: coverpoint CFI.op {
         type_option.weight = 0;
         // checks that a convert is happening (F2X, X2F, or F2F)
@@ -136,78 +115,6 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     }
 
     // cases iii & iv
-
-    //                                          Guard bit                                       sticky bit
-    int_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT +1] == 1) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    uint_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 2  : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT] == 1) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    long_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG +1] == 1) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    ulong_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 2 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG] == 1) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    int_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT +1] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    uint_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 2  : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    long_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG +1] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    ulong_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 2 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
 
     //                                          Guard bit                                       sticky bit
     F32_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 2) : 0]}
@@ -302,78 +209,6 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     // cases v & vi
 
     //                                          Guard bit                                       sticky bit
-    int_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT +1] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    uint_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 2  : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    long_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG +1] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    ulong_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 2 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG] == 0) {
-            type_option.weight = 0;
-
-            bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    int_minNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT +1] == '1) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    uint_minNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_INT - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_INT - 2  : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_INT] == '1) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    long_minNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 1 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG +1] == '1) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
-    ulong_minNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - SIZEOF_LONG - 1)], |CFI.intermM[INTERM_M_BITS - SIZEOF_LONG - 2 : 0]}
-    //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 : INTERM_M_BITS - SIZEOF_LONG] == '1) {
-            type_option.weight = 0;
-
-            bins minNorm_m_3ulp[] = {[2'b01 : 2'b11]};
-    }
-
-    //                                          Guard bit                                       sticky bit
     F32_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 2) : 0]}
     //   implicit leading 1 (norm)           all zero fraction (except for Guard and sticky)
         iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 -: F32_M_BITS] == 0) {
@@ -466,34 +301,6 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
     // cases vii & viii
 
-    int_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
-        type_option.weight = 0;
-
-        // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - SIZEOF_INT - 1)) - 1)]};
-    }
-
-    uint_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
-        type_option.weight = 0;
-
-        // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - SIZEOF_INT - 2)) - 1)]};
-    }
-
-    long_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
-        type_option.weight = 0;
-
-        // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - SIZEOF_LONG - 1)) - 1)]};
-    }
-
-    ulong_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
-        type_option.weight = 0;
-
-        // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - SIZEOF_LONG - 2)) - 1)]};
-    }
-
     F32_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
         type_option.weight = 0;
 
@@ -543,134 +350,10 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
 // TODO: need to add helper coverpoints for int formats, and fmt coverpoints for available conversion destination formats
 
-    B5_int_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  int_result_fmt {
-        bins narrow_f64_to_int  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_int = binsof(FP_convert_fmt.fmt_quad);
-    }
-    B5_uint_convert_subnorm: cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt, uint_result_fmt {
-        bins narrow_f64_to_uint  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_uint = binsof(FP_convert_fmt.fmt_quad);
-    }
-
-    B5_int_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, int_minSubNorm_p_3ulp, FP_convert_fmt,  int_result_fmt {
-        bins narrow_f64_to_int  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_int = binsof(FP_convert_fmt.fmt_quad);
-    }
-    B5_uint_convert_minSubNorm_p_3ulp: cross FP_convert_ops, rounding_mode_all, uint_minSubNorm_p_3ulp, FP_convert_fmt, uint_result_fmt {
-        bins narrow_f64_to_uint  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_uint = binsof(FP_convert_fmt.fmt_quad);
-    }
-
-    B5_int_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, int_minSubNorm_m_3ulp, FP_convert_fmt,  int_result_fmt {
-        bins narrow_f64_to_int  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_int = binsof(FP_convert_fmt.fmt_quad);
-    }
-    B5_uint_convert_minSubNorm_m_3ulp: cross FP_convert_ops, rounding_mode_all, uint_minSubNorm_m_3ulp, FP_convert_fmt, uint_result_fmt {
-        bins narrow_f64_to_uint  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_uint = binsof(FP_convert_fmt.fmt_quad);
-    }
-
-    B5_int_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, int_minNorm_p_3ulp, FP_convert_fmt,  int_result_fmt {
-        bins narrow_f64_to_int  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_int = binsof(FP_convert_fmt.fmt_quad);
-    }
-    B5_uint_convert_minNorm_p_3ulp: cross FP_convert_ops, rounding_mode_all, uint_minNorm_p_3ulp, FP_convert_fmt, uint_result_fmt {
-        bins narrow_f64_to_uint  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_uint = binsof(FP_convert_fmt.fmt_quad);
-    }
-
-    B5_int_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, int_minNorm_m_3ulp, FP_convert_fmt,  int_result_fmt {
-        bins narrow_f64_to_int  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_int = binsof(FP_convert_fmt.fmt_quad);
-    }
-    B5_uint_convert_minNorm_m_3ulp: cross FP_convert_ops, rounding_mode_all, uint_minNorm_m_3ulp, FP_convert_fmt, uint_result_fmt {
-        bins narrow_f64_to_uint  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_uint = binsof(FP_convert_fmt.fmt_quad);
-    }
-
-    B5_int_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, int_btw_minSubNorm_zero, FP_convert_fmt,  int_result_fmt {
-        bins narrow_f64_to_int  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_int = binsof(FP_convert_fmt.fmt_quad);
-    }
-    B5_uint_convert_btw_minSubNorm_zero: cross FP_convert_ops, rounding_mode_all, uint_btw_minSubNorm_zero, FP_convert_fmt, uint_result_fmt {
-        bins narrow_f64_to_uint  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_uint = binsof(FP_convert_fmt.fmt_quad);
-    }
-
-    B5_int_convert_minNorm_p5_exp_range:  cross FP_convert_ops, rounding_mode_all, FP_minNorm_p5_exp_range, FP_convert_fmt,  int_result_fmt {
-        bins narrow_f64_to_int  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_int = binsof(FP_convert_fmt.fmt_quad);
-    }
-    B5_uint_convert_minNorm_p5_exp_range: cross FP_convert_ops, rounding_mode_all, FP_minNorm_p5_exp_range, FP_convert_fmt, uint_result_fmt {
-        bins narrow_f64_to_uint  = binsof(FP_convert_fmt.fmt_double);
-        bins narrow_f128_to_uint = binsof(FP_convert_fmt.fmt_quad);
-    }
-
-    `ifdef COVER_LONG
-
-        B5_long_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  long_result_fmt {
-            bins narrow_f64_to_long  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_long = binsof(FP_convert_fmt.fmt_quad);
         }
-        B5_ulong_convert_subnorm: cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt, ulong_result_fmt {
-            bins narrow_f64_to_ulong  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_ulong = binsof(FP_convert_fmt.fmt_quad);
         }
-
-        B5_long_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, long_minSubNorm_p_3ulp, FP_convert_fmt,  long_result_fmt {
-            bins narrow_f64_to_long  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_long = binsof(FP_convert_fmt.fmt_quad);
         }
-        B5_ulong_convert_minSubNorm_p_3ulp: cross FP_convert_ops, rounding_mode_all, ulong_minSubNorm_p_3ulp, FP_convert_fmt, ulong_result_fmt {
-            bins narrow_f64_to_ulong  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_ulong = binsof(FP_convert_fmt.fmt_quad);
         }
-
-        B5_long_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, long_minSubNorm_m_3ulp, FP_convert_fmt,  long_result_fmt {
-            bins narrow_f64_to_long  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_long = binsof(FP_convert_fmt.fmt_quad);
-        }
-        B5_ulong_convert_minSubNorm_m_3ulp: cross FP_convert_ops, rounding_mode_all, ulong_minSubNorm_m_3ulp, FP_convert_fmt, ulong_result_fmt {
-            bins narrow_f64_to_ulong  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_ulong = binsof(FP_convert_fmt.fmt_quad);
-        }
-
-        B5_long_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, long_minNorm_p_3ulp, FP_convert_fmt,  long_result_fmt {
-            bins narrow_f64_to_long  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_long = binsof(FP_convert_fmt.fmt_quad);
-        }
-        B5_ulong_convert_minNorm_p_3ulp: cross FP_convert_ops, rounding_mode_all, ulong_minNorm_p_3ulp, FP_convert_fmt, ulong_result_fmt {
-            bins narrow_f64_to_ulong  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_ulong = binsof(FP_convert_fmt.fmt_quad);
-        }
-
-        B5_long_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, long_minNorm_m_3ulp, FP_convert_fmt,  long_result_fmt {
-            bins narrow_f64_to_long  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_long = binsof(FP_convert_fmt.fmt_quad);
-        }
-        B5_ulong_convert_minNorm_m_3ulp: cross FP_convert_ops, rounding_mode_all, ulong_minNorm_m_3ulp, FP_convert_fmt, ulong_result_fmt {
-            bins narrow_f64_to_ulong  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_ulong = binsof(FP_convert_fmt.fmt_quad);
-        }
-
-        B5_long_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, long_btw_minSubNorm_zero, FP_convert_fmt,  long_result_fmt {
-            bins narrow_f64_to_long  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_long = binsof(FP_convert_fmt.fmt_quad);
-        }
-        B5_ulong_convert_btw_minSubNorm_zero: cross FP_convert_ops, rounding_mode_all, ulong_btw_minSubNorm_zero, FP_convert_fmt, ulong_result_fmt {
-            bins narrow_f64_to_ulong  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_ulong = binsof(FP_convert_fmt.fmt_quad);
-        }
-
-        B5_long_convert_minNorm_p5_exp_range:  cross FP_convert_ops, rounding_mode_all, FP_minNorm_p5_exp_range, FP_convert_fmt,  long_result_fmt {
-            bins narrow_f64_to_long  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_long = binsof(FP_convert_fmt.fmt_quad);
-        }
-        B5_ulong_convert_minNorm_p5_exp_range: cross FP_convert_ops, rounding_mode_all, FP_minNorm_p5_exp_range, FP_convert_fmt, ulong_result_fmt {
-            bins narrow_f64_to_ulong  = binsof(FP_convert_fmt.fmt_double);
-            bins narrow_f128_to_ulong = binsof(FP_convert_fmt.fmt_quad);
-        }
-    `endif // COVER_LONG
 
     `ifdef COVER_F32
         B5_F32_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F32_result_fmt;

--- a/coverage/covergroups/B5.svh
+++ b/coverage/covergroups/B5.svh
@@ -119,7 +119,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F32_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F32_M_BITS +1] == 1) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F32_M_BITS] == 1) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -128,7 +128,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F32_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           all zeros fraction (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F32_M_BITS +1] == 0) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F32_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minSubNorm_m_3ulp[] = {[2'b01 : 2'b11]};
@@ -137,7 +137,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F64_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F64_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F64_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F64_M_BITS +1] == 1) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F64_M_BITS] == 1) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -146,7 +146,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F64_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F64_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F64_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           all zeros fraction (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F64_M_BITS +1] == 0) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F64_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minSubNorm_m_3ulp[] = {[2'b01 : 2'b11]};
@@ -155,7 +155,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F128_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F128_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F128_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F128_M_BITS +1] == 1) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F128_M_BITS] == 1) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -164,7 +164,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F128_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F128_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F128_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           all zeros fraction (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F128_M_BITS +1] == 0) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F128_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minSubNorm_m_3ulp[] = {[2'b01 : 2'b11]};
@@ -173,7 +173,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F16_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F16_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F16_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F16_M_BITS +1] == 1) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F16_M_BITS] == 1) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -182,7 +182,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F16_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F16_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F16_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           all zeros fraction (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F16_M_BITS +1] == 0) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: F16_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minSubNorm_m_3ulp[] = {[2'b01 : 2'b11]};
@@ -191,7 +191,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     BF16_minSubNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - BF16_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - BF16_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           single 1 in LSB (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: BF16_M_BITS +1] == 1) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: BF16_M_BITS] == 1) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -200,7 +200,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     BF16_minSubNorm_m_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - BF16_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - BF16_M_BITS - 2) : 0]}
     //   implicit leading 0 (subnorm)           all zeros fraction (except for Guard and sticky)
-        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: BF16_M_BITS +1] == 0) {
+        iff (CFI.intermX == 0 && CFI.intermM[INTERM_M_BITS -1 -: BF16_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minSubNorm_m_3ulp[] = {[2'b01 : 2'b11]};
@@ -211,7 +211,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F32_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F32_M_BITS - 2) : 0]}
     //   implicit leading 1 (norm)           all zero fraction (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 -: F32_M_BITS] == 0) {
+        iff (CFI.intermX == 1 && CFI.intermM[INTERM_M_BITS -1 -: F32_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -229,7 +229,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F64_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F64_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F64_M_BITS - 2) : 0]}
     //   implicit leading 1 (norm)           all zero fraction (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 -: F64_M_BITS] == 0) {
+        iff (CFI.intermX == 1 && CFI.intermM[INTERM_M_BITS -1 -: F64_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -247,7 +247,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F128_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F128_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F128_M_BITS - 2) : 0]}
     //   implicit leading 1 (norm)           all zero fraction (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 -: F128_M_BITS] == 0) {
+        iff (CFI.intermX == 1 && CFI.intermM[INTERM_M_BITS -1 -: F128_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -265,7 +265,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     F16_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - F16_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - F16_M_BITS - 2) : 0]}
     //   implicit leading 1 (norm)           all zero fraction (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 -: F16_M_BITS] == 0) {
+        iff (CFI.intermX == 1 && CFI.intermM[INTERM_M_BITS -1 -: F16_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -283,7 +283,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     //                                          Guard bit                                       sticky bit
     BF16_minNorm_p_3ulp: coverpoint {CFI.intermM[(INTERM_M_BITS - BF16_M_BITS - 1)], |CFI.intermM[(INTERM_M_BITS - BF16_M_BITS - 2) : 0]}
     //   implicit leading 1 (norm)           all zero fraction (except for Guard and sticky)
-        iff (CFI.intermX != 0 && CFI.intermM[INTERM_M_BITS -1 -: BF16_M_BITS] == 0) {
+        iff (CFI.intermX == 1 && CFI.intermM[INTERM_M_BITS -1 -: BF16_M_BITS] == 0) {
             type_option.weight = 0;
 
             bins minNorm_p_3ulp[] = {[2'b00 : 2'b11]};
@@ -305,35 +305,35 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
         type_option.weight = 0;
 
         // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F32_M_BITS - 2)) - 1)]};
+        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F32_M_BITS - 1)) - 1)]};
     }
 
     F64_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
         type_option.weight = 0;
 
         // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F64_M_BITS - 2)) - 1)]};
+        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F64_M_BITS - 1)) - 1)]};
     }
 
     F128_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
         type_option.weight = 0;
 
         // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F128_M_BITS - 2)) - 1)]};
+        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F128_M_BITS - 1)) - 1)]};
     }
 
     F16_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
         type_option.weight = 0;
 
         // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F16_M_BITS - 2)) - 1)]};
+        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - F16_M_BITS - 1)) - 1)]};
     }
 
     BF16_btw_minSubNorm_zero: coverpoint CFI.intermM iff (CFI.intermX == 0) {
         type_option.weight = 0;
 
         // shift 1 into the ULP position, subtract one to be in the exclusive range (0 , minSubNorm)
-        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - BF16_M_BITS - 2)) - 1)]};
+        bins btw_minSubNorm_zero = {[1 : ((INTERM_M_BITS'(1) << (INTERM_M_BITS - BF16_M_BITS - 1)) - 1)]};
     }
 
     // case ix
@@ -350,20 +350,30 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
 // TODO: need to add helper coverpoints for int formats, and fmt coverpoints for available conversion destination formats
 
-        }
-        }
-        }
-        }
-
     `ifdef COVER_F32
         B5_F32_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F32_result_fmt;
-        B5_F32_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_p_3ulp,   F32_result_fmt;
-        B5_F32_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_m_3ulp,   F32_result_fmt {
-            ignore_bins impossible_addsub = binsof(FP_result_ops.add) && binsof(FP_result_ops.add);
+        B5_F32_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_p_3ulp,   F32_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F32_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_p_3ulp,      F32_result_fmt;
-        B5_F32_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_m_3ulp,      F32_result_fmt;
-        B5_F32_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F32_btw_minSubNorm_zero, F32_result_fmt;
+        B5_F32_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_m_3ulp,   F32_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
+        B5_F32_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_p_3ulp,      F32_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F32_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_m_3ulp,      F32_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F32_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F32_btw_minSubNorm_zero, F32_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
         B5_F32_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range, F32_result_fmt;
 
 
@@ -371,12 +381,12 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
@@ -385,12 +395,12 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
@@ -399,12 +409,12 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
@@ -413,12 +423,12 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
@@ -427,26 +437,26 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
 
-        B5_F32_convert_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F32_btw_minSubNorm_zero, FP_convert_fmt, F32_result_fmt {
+        B5_F32_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F32_btw_minSubNorm_zero, FP_convert_fmt, F32_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
@@ -455,12 +465,12 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_f16_to_f32 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_single);
+                ignore_bins widen_bf16_to_f32 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
@@ -469,13 +479,28 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
     `ifdef COVER_F64
         B5_F64_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F64_result_fmt;
-        B5_F64_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_p_3ulp,   F64_result_fmt;
-        B5_F64_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_m_3ulp,   F64_result_fmt {
-            ignore_bins impossible_addsub = binsof(FP_result_ops.add) && binsof(FP_result_ops.add);
+        B5_F64_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_p_3ulp,   F64_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F64_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_p_3ulp,      F64_result_fmt;
-        B5_F64_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_m_3ulp,      F64_result_fmt;
-        B5_F64_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F64_btw_minSubNorm_zero, F64_result_fmt;
+        B5_F64_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_m_3ulp,   F64_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
+        B5_F64_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_p_3ulp,      F64_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F64_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_m_3ulp,      F64_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F64_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F64_btw_minSubNorm_zero, F64_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
         B5_F64_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range, F64_result_fmt;
 
 
@@ -483,17 +508,17 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
 
             `ifdef COVER_F32
-                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_single);
             `endif // COVER_F32
 
         }
@@ -502,17 +527,17 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
 
             `ifdef COVER_F32
-                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_single);
             `endif // COVER_F32
 
         }
@@ -521,17 +546,17 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
 
             `ifdef COVER_F32
-                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_single);
             `endif // COVER_F32
 
         }
@@ -540,17 +565,17 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
 
             `ifdef COVER_F32
-                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_single);
             `endif // COVER_F32
 
         }
@@ -559,36 +584,36 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
 
             `ifdef COVER_F32
-                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_single);
             `endif // COVER_F32
 
         }
 
-        B5_F64_convert_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F64_btw_minSubNorm_zero, FP_convert_fmt, F64_result_fmt {
+        B5_F64_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F64_btw_minSubNorm_zero, FP_convert_fmt, F64_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
 
             `ifdef COVER_F32
-                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_single);
             `endif // COVER_F32
 
         }
@@ -597,17 +622,17 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
-                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f16_to_f64 = binsof(FP_convert_fmt.fmt_half);
             `endif // COVER_F16
 
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_bf16_to_f64 = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
 
             `ifdef COVER_F32
-                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_double);
+                ignore_bins widen_f32_to_f64 = binsof(FP_convert_fmt.fmt_single);
             `endif // COVER_F32
 
         }
@@ -616,230 +641,78 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
     `ifdef COVER_F128
         B5_F128_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,               F128_result_fmt;
-        B5_F128_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_p_3ulp,   F128_result_fmt;
-        B5_F128_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_m_3ulp,   F128_result_fmt {
-            ignore_bins impossible_addsub = binsof(FP_result_ops.add) && binsof(FP_result_ops.add);
+        B5_F128_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_p_3ulp,   F128_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F128_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_p_3ulp,      F128_result_fmt;
-        B5_F128_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_m_3ulp,      F128_result_fmt;
-        B5_F128_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F128_btw_minSubNorm_zero, F128_result_fmt;
+        B5_F128_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_m_3ulp,   F128_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
+        B5_F128_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_p_3ulp,      F128_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F128_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_m_3ulp,      F128_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F128_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F128_btw_minSubNorm_zero, F128_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
         B5_F128_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range,  F128_result_fmt;
 
 
-        B5_F128_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F128_result_fmt {
-            ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_quad);
-
-            `ifdef COVER_F16
-                ignore_bins widen_f16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F16
-
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_BF16
-
-
-            `ifdef COVER_F32
-                ignore_bins widen_f32_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F32
-
-
-            `ifdef COVER_F64
-                ignore_bins widen_f64_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F64
-
-        }
-
-        B5_F128_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F128_minSubNorm_p_3ulp, FP_convert_fmt,  F128_result_fmt {
-            ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_quad);
-
-            `ifdef COVER_F16
-                ignore_bins widen_f16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F16
-
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_BF16
-
-
-            `ifdef COVER_F32
-                ignore_bins widen_f32_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F32
-
-
-            `ifdef COVER_F64
-                ignore_bins widen_f64_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F64
-
-        }
-
-        B5_F128_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F128_minSubNorm_m_3ulp, FP_convert_fmt,  F128_result_fmt {
-            ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_quad);
-
-            `ifdef COVER_F16
-                ignore_bins widen_f16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F16
-
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_BF16
-
-
-            `ifdef COVER_F32
-                ignore_bins widen_f32_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F32
-
-
-            `ifdef COVER_F64
-                ignore_bins widen_f64_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F64
-
-        }
-
-        B5_F128_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F128_minNorm_p_3ulp, FP_convert_fmt,  F128_result_fmt {
-            ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_quad);
-
-            `ifdef COVER_F16
-                ignore_bins widen_f16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F16
-
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_BF16
-
-
-            `ifdef COVER_F32
-                ignore_bins widen_f32_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F32
-
-
-            `ifdef COVER_F64
-                ignore_bins widen_f64_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F64
-
-        }
-
-        B5_F128_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F128_minNorm_m_3ulp, FP_convert_fmt,  F128_result_fmt {
-            ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_quad);
-
-            `ifdef COVER_F16
-                ignore_bins widen_f16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F16
-
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_BF16
-
-
-            `ifdef COVER_F32
-                ignore_bins widen_f32_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F32
-
-
-            `ifdef COVER_F64
-                ignore_bins widen_f64_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F64
-
-        }
-
-        B5_F128_convert_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F128_btw_minSubNorm_zero, FP_convert_fmt, F128_result_fmt {
-            ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_quad);
-
-            `ifdef COVER_F16
-                ignore_bins widen_f16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F16
-
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_BF16
-
-
-            `ifdef COVER_F32
-                ignore_bins widen_f32_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F32
-
-
-            `ifdef COVER_F64
-                ignore_bins widen_f64_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F64
-
-        }
-
-        B5_F128_convert_minNorm_p5_exp_range:  cross FP_convert_ops, rounding_mode_all, FP_minNorm_p5_exp_range, FP_convert_fmt,  F128_result_fmt {
-            ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_quad);
-
-            `ifdef COVER_F16
-                ignore_bins widen_f16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F16
-
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_BF16
-
-
-            `ifdef COVER_F32
-                ignore_bins widen_f32_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F32
-
-
-            `ifdef COVER_F64
-                ignore_bins widen_f64_to_f128 = binsof(FP_convert_fmt.fmt_quad);
-            `endif // COVER_F64
-
-        }
-
+        // All Converts to F128 would be widening
     `endif
 
     `ifdef COVER_F16
         B5_F16_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F16_result_fmt;
-        B5_F16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_p_3ulp,   F16_result_fmt;
-        B5_F16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_m_3ulp,   F16_result_fmt {
-            ignore_bins impossible_addsub = binsof(FP_result_ops.add) && binsof(FP_result_ops.add);
+        B5_F16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_p_3ulp,   F16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_p_3ulp,      F16_result_fmt;
-        B5_F16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_m_3ulp,      F16_result_fmt;
-        B5_F16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F16_btw_minSubNorm_zero, F16_result_fmt;
+        B5_F16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_m_3ulp,   F16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
+        B5_F16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_p_3ulp,      F16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_m_3ulp,      F16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F16_btw_minSubNorm_zero, F16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
         B5_F16_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range, F16_result_fmt;
 
 
         B5_F16_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f16 = binsof(FP_convert_fmt.fmt_half);
-            `endif // COVER_BF16
-
         }
 
         B5_F16_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minSubNorm_p_3ulp, FP_convert_fmt,  F16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f16 = binsof(FP_convert_fmt.fmt_half);
-            `endif // COVER_BF16
-
         }
 
         B5_F16_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minSubNorm_m_3ulp, FP_convert_fmt,  F16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f16 = binsof(FP_convert_fmt.fmt_half);
-            `endif // COVER_BF16
-
         }
 
         B5_F16_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minNorm_p_3ulp, FP_convert_fmt,  F16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f16 = binsof(FP_convert_fmt.fmt_half);
+                ignore_bins bf16_not_widen_enough = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
@@ -848,69 +721,111 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
 
             `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f16 = binsof(FP_convert_fmt.fmt_half);
+                ignore_bins bf16_not_wide_enough = binsof(FP_convert_fmt.fmt_bf16);
             `endif // COVER_BF16
 
         }
 
-        B5_F16_convert_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F16_btw_minSubNorm_zero, FP_convert_fmt, F16_result_fmt {
+        B5_F16_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F16_btw_minSubNorm_zero, FP_convert_fmt, F16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f16 = binsof(FP_convert_fmt.fmt_half);
-            `endif // COVER_BF16
-
         }
 
         B5_F16_convert_minNorm_p5_exp_range:  cross FP_convert_ops, rounding_mode_all, FP_minNorm_p5_exp_range, FP_convert_fmt,  F16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
-
-            `ifdef COVER_BF16
-                ignore_bins widen_bf16_to_f16 = binsof(FP_convert_fmt.fmt_half);
-            `endif // COVER_BF16
-
         }
 
     `endif
 
     `ifdef COVER_BF16
         B5_BF16_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,               BF16_result_fmt;
-        B5_BF16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_p_3ulp,   BF16_result_fmt;
-        B5_BF16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_m_3ulp,   BF16_result_fmt {
-            ignore_bins impossible_addsub = binsof(FP_result_ops.add) && binsof(FP_result_ops.add);
+        B5_BF16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_p_3ulp,   BF16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_BF16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_p_3ulp,      BF16_result_fmt;
-        B5_BF16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_m_3ulp,      BF16_result_fmt;
-        B5_BF16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, BF16_result_fmt;
+        B5_BF16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_m_3ulp,   BF16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
+        B5_BF16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_p_3ulp,      BF16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+
+            ignore_bins prime_value = binsof(FP_result_ops.mul) && (binsof(BF16_minNorm_p_3ulp.minNorm_p_3ulp) intersect {2});
+        }
+        B5_BF16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_m_3ulp,      BF16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_BF16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, BF16_result_fmt {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+        }
         B5_BF16_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range,  BF16_result_fmt;
 
 
         B5_BF16_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  BF16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
+
+            `ifdef COVER_BF16
+                ignore_bins widen_f16_to_bf16 = binsof(FP_convert_fmt.fmt_half);
+            `endif // COVER_BF16
+
         }
 
         B5_BF16_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minSubNorm_p_3ulp, FP_convert_fmt,  BF16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
+
+            `ifdef COVER_BF16
+                ignore_bins widen_f16_to_bf16 = binsof(FP_convert_fmt.fmt_half);
+            `endif // COVER_BF16
+
         }
 
         B5_BF16_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minSubNorm_m_3ulp, FP_convert_fmt,  BF16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
+
+            `ifdef COVER_BF16
+                ignore_bins widen_f16_to_bf16 = binsof(FP_convert_fmt.fmt_half);
+            `endif // COVER_BF16
+
         }
 
         B5_BF16_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minNorm_p_3ulp, FP_convert_fmt,  BF16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
+
+            `ifdef COVER_BF16
+                ignore_bins widen_f16_to_bf16 = binsof(FP_convert_fmt.fmt_half);
+            `endif // COVER_BF16
+
         }
 
         B5_BF16_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minNorm_m_3ulp, FP_convert_fmt,  BF16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
+
+            `ifdef COVER_BF16
+                ignore_bins widen_f16_to_bf16 = binsof(FP_convert_fmt.fmt_half);
+            `endif // COVER_BF16
+
         }
 
-        B5_BF16_convert_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, FP_convert_fmt, BF16_result_fmt {
+        B5_BF16_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, FP_convert_fmt, BF16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
+
+            `ifdef COVER_BF16
+                ignore_bins widen_f16_to_bf16 = binsof(FP_convert_fmt.fmt_half);
+            `endif // COVER_BF16
+
         }
 
         B5_BF16_convert_minNorm_p5_exp_range:  cross FP_convert_ops, rounding_mode_all, FP_minNorm_p5_exp_range, FP_convert_fmt,  BF16_result_fmt {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
+
+            `ifdef COVER_BF16
+                ignore_bins widen_f16_to_bf16 = binsof(FP_convert_fmt.fmt_half);
+            `endif // COVER_BF16
+
         }
 
     `endif

--- a/coverage/covergroups/B5.svh
+++ b/coverage/covergroups/B5.svh
@@ -31,7 +31,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
         bins fmsub  = {OP_FMSUB};
         bins fnmadd = {OP_FNMADD};
         bins fnmsub = {OP_FNMSUB};
-}
+    }
 
     rounding_mode_all: coverpoint CFI.rm {
         type_option.weight = 0;
@@ -65,6 +65,12 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     F128_result_fmt: coverpoint (CFI.resultFmt == FMT_QUAD) {
         type_option.weight = 0;
         bins f128 = {1};
+    }
+
+    interm_sign: coverpoint CFI.intermS {
+        type_option.weight = 0;
+        bins pos = {0};
+        bins neg = {1};
     }
 
     FP_convert_ops: coverpoint CFI.op {
@@ -351,33 +357,33 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 // TODO: need to add helper coverpoints for int formats, and fmt coverpoints for available conversion destination formats
 
     `ifdef COVER_F32
-        B5_F32_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F32_result_fmt;
-        B5_F32_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_p_3ulp,   F32_result_fmt {
+        B5_F32_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F32_result_fmt, interm_sign;
+        B5_F32_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_p_3ulp,   F32_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F32_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_m_3ulp,   F32_result_fmt {
+        B5_F32_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F32_minSubNorm_m_3ulp,   F32_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F32_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_p_3ulp,      F32_result_fmt {
-            ignore_bins impossible_add = binsof(FP_result_ops.add);
-            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
-            ignore_bins impossible_div = binsof(FP_result_ops.div);
-        }
-        B5_F32_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_m_3ulp,      F32_result_fmt {
+        B5_F32_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_p_3ulp,      F32_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
             ignore_bins impossible_div = binsof(FP_result_ops.div);
         }
-        B5_F32_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F32_btw_minSubNorm_zero, F32_result_fmt {
+        B5_F32_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F32_minNorm_m_3ulp,      F32_result_fmt, interm_sign {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F32_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F32_btw_minSubNorm_zero, F32_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
         B5_F32_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range, F32_result_fmt;
 
 
-        B5_F32_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F32_result_fmt {
+        B5_F32_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F32_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
@@ -391,7 +397,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F32_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minSubNorm_p_3ulp, FP_convert_fmt,  F32_result_fmt {
+        B5_F32_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minSubNorm_p_3ulp, FP_convert_fmt,  F32_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
@@ -405,7 +411,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F32_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minSubNorm_m_3ulp, FP_convert_fmt,  F32_result_fmt {
+        B5_F32_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minSubNorm_m_3ulp, FP_convert_fmt,  F32_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
@@ -419,7 +425,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F32_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minNorm_p_3ulp, FP_convert_fmt,  F32_result_fmt {
+        B5_F32_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minNorm_p_3ulp, FP_convert_fmt,  F32_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
@@ -433,7 +439,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F32_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minNorm_m_3ulp, FP_convert_fmt,  F32_result_fmt {
+        B5_F32_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F32_minNorm_m_3ulp, FP_convert_fmt,  F32_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
@@ -447,7 +453,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F32_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F32_btw_minSubNorm_zero, FP_convert_fmt, F32_result_fmt {
+        B5_F32_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F32_btw_minSubNorm_zero, FP_convert_fmt, F32_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_single);
 
             `ifdef COVER_F16
@@ -478,33 +484,33 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     `endif
 
     `ifdef COVER_F64
-        B5_F64_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F64_result_fmt;
-        B5_F64_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_p_3ulp,   F64_result_fmt {
+        B5_F64_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F64_result_fmt, interm_sign;
+        B5_F64_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_p_3ulp,   F64_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F64_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_m_3ulp,   F64_result_fmt {
+        B5_F64_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F64_minSubNorm_m_3ulp,   F64_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F64_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_p_3ulp,      F64_result_fmt {
-            ignore_bins impossible_add = binsof(FP_result_ops.add);
-            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
-            ignore_bins impossible_div = binsof(FP_result_ops.div);
-        }
-        B5_F64_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_m_3ulp,      F64_result_fmt {
+        B5_F64_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_p_3ulp,      F64_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
             ignore_bins impossible_div = binsof(FP_result_ops.div);
         }
-        B5_F64_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F64_btw_minSubNorm_zero, F64_result_fmt {
+        B5_F64_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F64_minNorm_m_3ulp,      F64_result_fmt, interm_sign {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F64_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F64_btw_minSubNorm_zero, F64_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
         B5_F64_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range, F64_result_fmt;
 
 
-        B5_F64_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F64_result_fmt {
+        B5_F64_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F64_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
@@ -523,7 +529,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F64_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minSubNorm_p_3ulp, FP_convert_fmt,  F64_result_fmt {
+        B5_F64_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minSubNorm_p_3ulp, FP_convert_fmt,  F64_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
@@ -542,7 +548,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F64_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minSubNorm_m_3ulp, FP_convert_fmt,  F64_result_fmt {
+        B5_F64_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minSubNorm_m_3ulp, FP_convert_fmt,  F64_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
@@ -561,7 +567,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F64_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minNorm_p_3ulp, FP_convert_fmt,  F64_result_fmt {
+        B5_F64_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minNorm_p_3ulp, FP_convert_fmt,  F64_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
@@ -580,7 +586,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F64_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minNorm_m_3ulp, FP_convert_fmt,  F64_result_fmt {
+        B5_F64_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F64_minNorm_m_3ulp, FP_convert_fmt,  F64_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
@@ -599,7 +605,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F64_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F64_btw_minSubNorm_zero, FP_convert_fmt, F64_result_fmt {
+        B5_F64_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F64_btw_minSubNorm_zero, FP_convert_fmt, F64_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_double);
 
             `ifdef COVER_F16
@@ -640,26 +646,26 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     `endif
 
     `ifdef COVER_F128
-        B5_F128_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,               F128_result_fmt;
-        B5_F128_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_p_3ulp,   F128_result_fmt {
+        B5_F128_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,               F128_result_fmt, interm_sign;
+        B5_F128_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_p_3ulp,   F128_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F128_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_m_3ulp,   F128_result_fmt {
+        B5_F128_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F128_minSubNorm_m_3ulp,   F128_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F128_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_p_3ulp,      F128_result_fmt {
-            ignore_bins impossible_add = binsof(FP_result_ops.add);
-            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
-            ignore_bins impossible_div = binsof(FP_result_ops.div);
-        }
-        B5_F128_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_m_3ulp,      F128_result_fmt {
+        B5_F128_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_p_3ulp,      F128_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
             ignore_bins impossible_div = binsof(FP_result_ops.div);
         }
-        B5_F128_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F128_btw_minSubNorm_zero, F128_result_fmt {
+        B5_F128_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F128_minNorm_m_3ulp,      F128_result_fmt, interm_sign {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F128_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F128_btw_minSubNorm_zero, F128_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
@@ -670,45 +676,45 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     `endif
 
     `ifdef COVER_F16
-        B5_F16_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F16_result_fmt;
-        B5_F16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_p_3ulp,   F16_result_fmt {
+        B5_F16_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,              F16_result_fmt, interm_sign;
+        B5_F16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_p_3ulp,   F16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_m_3ulp,   F16_result_fmt {
+        B5_F16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, F16_minSubNorm_m_3ulp,   F16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_F16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_p_3ulp,      F16_result_fmt {
-            ignore_bins impossible_add = binsof(FP_result_ops.add);
-            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
-            ignore_bins impossible_div = binsof(FP_result_ops.div);
-        }
-        B5_F16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_m_3ulp,      F16_result_fmt {
+        B5_F16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_p_3ulp,      F16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
             ignore_bins impossible_div = binsof(FP_result_ops.div);
         }
-        B5_F16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F16_btw_minSubNorm_zero, F16_result_fmt {
+        B5_F16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, F16_minNorm_m_3ulp,      F16_result_fmt, interm_sign {
+            ignore_bins impossible_add = binsof(FP_result_ops.add);
+            ignore_bins impossible_sub = binsof(FP_result_ops.sub);
+            ignore_bins impossible_div = binsof(FP_result_ops.div);
+        }
+        B5_F16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, F16_btw_minSubNorm_zero, F16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
         B5_F16_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range, F16_result_fmt;
 
 
-        B5_F16_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F16_result_fmt {
+        B5_F16_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  F16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
         }
 
-        B5_F16_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minSubNorm_p_3ulp, FP_convert_fmt,  F16_result_fmt {
+        B5_F16_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minSubNorm_p_3ulp, FP_convert_fmt,  F16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
         }
 
-        B5_F16_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minSubNorm_m_3ulp, FP_convert_fmt,  F16_result_fmt {
+        B5_F16_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minSubNorm_m_3ulp, FP_convert_fmt,  F16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
         }
 
-        B5_F16_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minNorm_p_3ulp, FP_convert_fmt,  F16_result_fmt {
+        B5_F16_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minNorm_p_3ulp, FP_convert_fmt,  F16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
 
             `ifdef COVER_BF16
@@ -717,7 +723,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F16_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minNorm_m_3ulp, FP_convert_fmt,  F16_result_fmt {
+        B5_F16_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, F16_minNorm_m_3ulp, FP_convert_fmt,  F16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
 
             `ifdef COVER_BF16
@@ -726,7 +732,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_F16_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F16_btw_minSubNorm_zero, FP_convert_fmt, F16_result_fmt {
+        B5_F16_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, F16_btw_minSubNorm_zero, FP_convert_fmt, F16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_half);
         }
 
@@ -737,35 +743,35 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
     `endif
 
     `ifdef COVER_BF16
-        B5_BF16_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,               BF16_result_fmt;
-        B5_BF16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_p_3ulp,   BF16_result_fmt {
+        B5_BF16_subnorm:              cross FP_result_ops, rounding_mode_all, FP_subnorm,               BF16_result_fmt, interm_sign;
+        B5_BF16_minSubNorm_p_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_p_3ulp,   BF16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_BF16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_m_3ulp,   BF16_result_fmt {
+        B5_BF16_minSubNorm_m_3ulp:    cross FP_result_ops, rounding_mode_all, BF16_minSubNorm_m_3ulp,   BF16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
-        B5_BF16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_p_3ulp,      BF16_result_fmt {
+        B5_BF16_minNorm_p_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_p_3ulp,      BF16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
             ignore_bins impossible_div = binsof(FP_result_ops.div);
 
             ignore_bins prime_value = binsof(FP_result_ops.mul) && (binsof(BF16_minNorm_p_3ulp.minNorm_p_3ulp) intersect {2});
         }
-        B5_BF16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_m_3ulp,      BF16_result_fmt {
+        B5_BF16_minNorm_m_3ulp:       cross FP_result_ops, rounding_mode_all, BF16_minNorm_m_3ulp,      BF16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
             ignore_bins impossible_div = binsof(FP_result_ops.div);
         }
-        B5_BF16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, BF16_result_fmt {
+        B5_BF16_btw_minSubNorm_zero:  cross FP_result_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, BF16_result_fmt, interm_sign {
             ignore_bins impossible_add = binsof(FP_result_ops.add);
             ignore_bins impossible_sub = binsof(FP_result_ops.sub);
         }
         B5_BF16_minNorm_p5_exp_range: cross FP_result_ops, rounding_mode_all, FP_minNorm_p5_exp_range,  BF16_result_fmt;
 
 
-        B5_BF16_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  BF16_result_fmt {
+        B5_BF16_convert_subnorm:  cross FP_convert_ops, rounding_mode_all, FP_subnorm, FP_convert_fmt,  BF16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
 
             `ifdef COVER_BF16
@@ -774,7 +780,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_BF16_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minSubNorm_p_3ulp, FP_convert_fmt,  BF16_result_fmt {
+        B5_BF16_convert_minSubNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minSubNorm_p_3ulp, FP_convert_fmt,  BF16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
 
             `ifdef COVER_BF16
@@ -783,7 +789,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_BF16_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minSubNorm_m_3ulp, FP_convert_fmt,  BF16_result_fmt {
+        B5_BF16_convert_minSubNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minSubNorm_m_3ulp, FP_convert_fmt,  BF16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
 
             `ifdef COVER_BF16
@@ -792,7 +798,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_BF16_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minNorm_p_3ulp, FP_convert_fmt,  BF16_result_fmt {
+        B5_BF16_convert_minNorm_p_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minNorm_p_3ulp, FP_convert_fmt,  BF16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
 
             `ifdef COVER_BF16
@@ -801,7 +807,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_BF16_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minNorm_m_3ulp, FP_convert_fmt,  BF16_result_fmt {
+        B5_BF16_convert_minNorm_m_3ulp:  cross FP_convert_ops, rounding_mode_all, BF16_minNorm_m_3ulp, FP_convert_fmt,  BF16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
 
             `ifdef COVER_BF16
@@ -810,7 +816,7 @@ covergroup B5_cg (virtual coverfloat_interface CFI);
 
         }
 
-        B5_BF16_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, FP_convert_fmt, BF16_result_fmt {
+        B5_BF16_convert_btw_minSubNorm_zero:  cross FP_convert_ops, rounding_mode_all, BF16_btw_minSubNorm_zero, FP_convert_fmt, BF16_result_fmt, interm_sign {
             ignore_bins invalid_convert = binsof(FP_convert_fmt.fmt_bf16);
 
             `ifdef COVER_BF16


### PR DESCRIPTION
This PR removes integer conversions from the B5 covergroup, adds a sign to the relevant coverpoints, and fixes incorrect bit locations for certain coverpoints. 