### PR TITLE
B22-24 Coverage Fixes

### DIFF
--- a/coverage/covergroups/B22.svh
+++ b/coverage/covergroups/B22.svh
@@ -43,31 +43,31 @@ covergroup B22_cg (virtual coverfloat_interface CFI);
     }
 
     // Sign coverpoints
-    F16_sign: coverpoint CFI.result[F16_SIGN_BIT] {
+    F16_sign: coverpoint CFI.a[F16_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    BF16_sign: coverpoint CFI.result[BF16_SIGN_BIT] {
+    BF16_sign: coverpoint CFI.a[BF16_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    F32_sign: coverpoint CFI.result[F32_SIGN_BIT] {
+    F32_sign: coverpoint CFI.a[F32_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    F64_sign: coverpoint CFI.result[F64_SIGN_BIT] {
+    F64_sign: coverpoint CFI.a[F64_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    F128_sign: coverpoint CFI.result[F128_SIGN_BIT] {
+    F128_sign: coverpoint CFI.a[F128_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
@@ -84,6 +84,11 @@ covergroup B22_cg (virtual coverfloat_interface CFI);
         type_option.weight = 0;
 
         bins int32 = {FMT_INT};
+    }
+
+    result_uint32_fmt: coverpoint CFI.resultFmt {
+        type_option.weight = 0;
+
         bins uint32 = {FMT_UINT};
     }
 
@@ -91,23 +96,28 @@ covergroup B22_cg (virtual coverfloat_interface CFI);
         type_option.weight = 0;
 
         bins int64 = {FMT_LONG};
+    }
+
+    result_ulong64_fmt: coverpoint CFI.resultFmt {
+        type_option.weight = 0;
+
         bins uint64 = {FMT_ULONG};
     }
 
-    //F16's max unbiased exponent is 16, below the limit for both int and long bit width
+    //F16's max unbiased exponent is 15, below the limit for both int and long bit width
     //This will be able to satisfy both the int and long possible cases for half precision
     f16_exponent_dif: coverpoint $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)){
         type_option.weight = 0;
 
-        bins less_than_neg_3 = {[$:-2]};
-        bins between_neg_3_and_16[] = {[-3:16]};
+        bins less_than_neg_3 = {[$:-4]};
+        bins between_neg_3_and_15[] = {[-3:15]};
     }
 
     //Input Exponent Coverpoint, only need 2 because unsigned/signed ints/longs have same width
     exponent_dif_int32: coverpoint $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)){
         type_option.weight = 0;
 
-        bins less_than_neg_3 = {[$:-2]};
+        bins less_than_neg_3 = {[$:-4]};
         bins between_neg_3_and_int_width_plus_3[] = {[-3:SIZEOF_INT + 3]};
         bins greater_than_int_width_plus_3 = {[SIZEOF_INT + 4:$]};
     }
@@ -115,7 +125,7 @@ covergroup B22_cg (virtual coverfloat_interface CFI);
     exponent_dif_long64: coverpoint $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)){
         type_option.weight = 0;
 
-        bins less_than_neg_3 = {[$:-2]};
+        bins less_than_neg_3 = {[$:-4]};
         bins between_neg_3_and_int_width_plus_3[] = {[-3:SIZEOF_LONG + 3]};
         bins greater_than_int_width_plus_3 = {[SIZEOF_LONG + 4:$]};
     }
@@ -124,40 +134,55 @@ covergroup B22_cg (virtual coverfloat_interface CFI);
     //FMT_HALF
     `ifdef COVER_F16
         B22_F16_INT: cross F16_input_fmt, F16_sign, FP2INT_op, result_int32_fmt, f16_exponent_dif;
+        B22_F16_UINT: cross F16_input_fmt, FP2INT_op, result_uint32_fmt, f16_exponent_dif;
+
         `ifdef COVER_LONG
             B22_F16_LONG: cross F16_input_fmt, F16_sign, FP2INT_op, result_long64_fmt, f16_exponent_dif;
+            B22_F16_ULONG: cross F16_input_fmt, FP2INT_op, result_ulong64_fmt, f16_exponent_dif;
         `endif
     `endif
 
-    //FMT_BF16
+    // FMT_BF16
     `ifdef COVER_BF16
         B22_BF16_INT: cross BF16_input_fmt, BF16_sign, FP2INT_op, result_int32_fmt, exponent_dif_int32;
+        B22_BF16_UINT: cross BF16_input_fmt, FP2INT_op, result_uint32_fmt, exponent_dif_int32;
+
         `ifdef COVER_LONG
             B22_BF16_LONG: cross BF16_input_fmt, BF16_sign, FP2INT_op, result_long64_fmt, exponent_dif_long64;
+            B22_BF16_ULONG: cross BF16_input_fmt, FP2INT_op, result_ulong64_fmt, exponent_dif_long64;
         `endif
     `endif
 
-    //FMT_SINGLE
+    // FMT_SINGLE
     `ifdef COVER_F32
         B22_F32_INT: cross F32_input_fmt, F32_sign, FP2INT_op, result_int32_fmt, exponent_dif_int32;
+        B22_F32_UINT: cross F32_input_fmt, FP2INT_op, result_uint32_fmt, exponent_dif_int32;
+
         `ifdef COVER_LONG
             B22_F32_LONG: cross F32_input_fmt, F32_sign, FP2INT_op, result_long64_fmt, exponent_dif_long64;
+            B22_F32_ULONG: cross F32_input_fmt, FP2INT_op, result_ulong64_fmt, exponent_dif_long64;
         `endif
     `endif
 
-    //FMT_DOUBLE
+    // FMT_DOUBLE
     `ifdef COVER_F64
         B22_F64_INT: cross F64_input_fmt, F64_sign, FP2INT_op, result_int32_fmt, exponent_dif_int32;
+        B22_F64_UINT: cross F64_input_fmt, FP2INT_op, result_uint32_fmt, exponent_dif_int32;
+
         `ifdef COVER_LONG
             B22_F64_LONG: cross F64_input_fmt, F64_sign, FP2INT_op, result_long64_fmt, exponent_dif_long64;
+            B22_F64_ULONG: cross F64_input_fmt, FP2INT_op, result_ulong64_fmt, exponent_dif_long64;
         `endif
     `endif
 
-    //FMT_QUAD
+    // FMT_QUAD
     `ifdef COVER_F128
         B22_F128_INT: cross F128_input_fmt, F128_sign, FP2INT_op, result_int32_fmt, exponent_dif_int32;
+        B22_F128_UINT: cross F128_input_fmt, FP2INT_op, result_uint32_fmt, exponent_dif_int32;
+
         `ifdef COVER_LONG
             B22_F128_LONG: cross F128_input_fmt, F128_sign, FP2INT_op, result_long64_fmt, exponent_dif_long64;
+            B22_F128_ULONG: cross F128_input_fmt, FP2INT_op, result_ulong64_fmt, exponent_dif_long64;
         `endif
     `endif
 

--- a/coverage/covergroups/B23.svh
+++ b/coverage/covergroups/B23.svh
@@ -48,6 +48,16 @@ covergroup B23_cg (virtual coverfloat_interface CFI);
         bins convert_float_int = {1};
     }
 
+    // Rounding mode
+    rounding_mode_all: coverpoint (CFI.rm) {
+        type_option.weight = 0;
+        bins round_near_even   = {ROUND_NEAR_EVEN};
+        bins round_minmag      = {ROUND_MINMAG};
+        bins round_min         = {ROUND_MIN};
+        bins round_max         = {ROUND_MAX};
+        bins round_near_maxmag = {ROUND_NEAR_MAXMAG};
+    }
+
     //Proximity To Max Int Coverpoints
     proximity_to_max_uint32: coverpoint $signed(get_proximity_to_max_int(CFI.a, CFI.operandFmt, FMT_UINT)){
         type_option.weight = 0;
@@ -93,55 +103,92 @@ covergroup B23_cg (virtual coverfloat_interface CFI);
     //FP_16: No Cases
     //max_exp = 15; 2^15 < all possible values of maxInt
 
-    //BF_16 Cases:
-    //Each exponent must match the maxInt condition and each mantissa = 0
-    BF16_proximity_to_max_uint32: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 32 && CFI.a[BF16_M_UPPER: 0] == '0){
+    // BF_16 Cases:
+    // Each exponent must match the maxInt condition and each mantissa = 0
+    // or be exactly 1 ulp less than that
+    BF16_proximity_to_max_uint32: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 32 && CFI.a[BF16_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 31 && CFI.a[BF16_M_UPPER: 0] == '1 }){
         type_option.weight = 0;
 
-        bins BF16_max_int_plus_one_uint32 = {1};
+        bins BF16_max_int_plus_one_uint32 = {2'b10};
+        bins BF16_max_int_minus_one_uint32 = {2'b01};
+    }
+    BF16_proximity_to_max_int32: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 31 && CFI.a[BF16_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 30 && CFI.a[BF16_M_UPPER: 0] == '1 }){
+        type_option.weight = 0;
+
+        bins BF16_max_int_plus_one_int32 = {2'b10};
+        bins BF16_max_int_minus_one_int32 = {2'b01};
+    }
+    BF16_proximity_to_max_ulong64: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 64 && CFI.a[BF16_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[BF16_M_UPPER: 0] == '1 }){
+        type_option.weight = 0;
+
+        bins BF16_max_int_plus_one_ulong64 = {2'b10};
+        bins BF16_max_int_minus_one_ulong64 = {2'b01};
+    }
+    BF16_proximity_to_max_long64: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[BF16_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 62 && CFI.a[BF16_M_UPPER: 0] == '1 }){
+        type_option.weight = 0;
+
+        bins BF16_max_int_plus_one_long64 = {2'b10};
+        bins BF16_max_int_minus_one_long64 = {2'b01};
     }
 
-    BF16_proximity_to_max_int32: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 31 && CFI.a[BF16_M_UPPER: 0] == '0){
+    // F32 Cases:
+    F32_proximity_to_max_uint32: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 32 && CFI.a[F32_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 31 && CFI.a[F32_M_UPPER: 0] == '1 }){
         type_option.weight = 0;
 
-        bins BF16_max_int_plus_one_int32 = {1};
+        bins F32_max_int_plus_one_uint32 = {2'b10};
+        bins F32_max_int_minus_one_uint32 = {2'b01};
+    }
+    F32_proximity_to_max_int32: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 31 && CFI.a[F32_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 30 && CFI.a[F32_M_UPPER: 0] == '1 }){
+        type_option.weight = 0;
+
+        bins F32_max_int_plus_one_int32 = {2'b10};
+        bins F32_max_int_minus_one_int32 = {2'b01};
+    }
+    F32_proximity_to_max_ulong64: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 64 && CFI.a[F32_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[F32_M_UPPER: 0] == '1 }){
+        type_option.weight = 0;
+
+        bins F32_max_int_plus_one_ulong64 = {2'b10};
+        bins F32_max_int_minus_one_ulong64 = {2'b01};
+    }
+    F32_proximity_to_max_long64: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[F32_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 62 && CFI.a[F32_M_UPPER: 0] == '1 }){
+        type_option.weight = 0;
+
+        bins F32_max_int_plus_one_long64 = {2'b10};
+        bins F32_max_int_minus_one_long64 = {2'b01};
     }
 
-    BF16_proximity_to_max_ulong64: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 64 && CFI.a[BF16_M_UPPER: 0] == '0){
+    // F64 Cases: With 52 mantissa bits, there are only special cases for longs
+    F64_proximity_to_max_ulong64: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 64 && CFI.a[F64_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[F64_M_UPPER: 0] == '1 }){
         type_option.weight = 0;
 
-        bins BF16_max_int_plus_one_ulong64 = {1};
+        bins F64_max_int_plus_one_ulong64 = {2'b10};
+        bins F64_max_int_minus_one_ulong64 = {2'b01};
     }
-
-    BF16_proximity_to_max_long64: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[BF16_M_UPPER: 0] == '0){
+    F64_proximity_to_max_long64: coverpoint(
+        { $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[F64_M_UPPER: 0] == '0
+        , $signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 62 && CFI.a[F64_M_UPPER: 0] == '1 }){
         type_option.weight = 0;
 
-        bins BF16_max_int_plus_one_long64 = {1};
-    }
-
-    //F32 special coverpoints
-    F32_proximity_to_max_uint32: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 32 && CFI.a[F32_M_UPPER: 0] == '0){
-        type_option.weight = 0;
-
-        bins F32_max_int_plus_one_uint32 = {1};
-    }
-
-    F32_proximity_to_max_int32: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 31 && CFI.a[F32_M_UPPER: 0] == '0){
-        type_option.weight = 0;
-
-        bins F32_max_int_plus_one_int32 = {1};
-    }
-
-    F32_proximity_to_max_ulong64: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 64 && CFI.a[F32_M_UPPER: 0] == '0){
-        type_option.weight = 0;
-
-        bins F32_max_int_plus_one_ulong64 = {1};
-    }
-
-    F32_proximity_to_max_long64: coverpoint($signed(get_unbiased_exponent(CFI.a, CFI.operandFmt)) == 63 && CFI.a[F32_M_UPPER: 0] == '0){
-        type_option.weight = 0;
-
-        bins F32_max_int_plus_one_long64 = {1};
+        bins F64_max_int_plus_one_long64 = {2'b10};
+        bins F64_max_int_minus_one_long64 = {2'b01};
     }
 
     //Result format coverpoints
@@ -151,7 +198,7 @@ covergroup B23_cg (virtual coverfloat_interface CFI);
         bins int32 = {1};
     }
 
-    result_uint32_fmt: coverpoint(CFI.result == FMT_UINT) {
+    result_uint32_fmt: coverpoint(CFI.resultFmt == FMT_UINT) {
         type_option.weight = 0;
 
         bins uint32 = {1};
@@ -184,11 +231,11 @@ covergroup B23_cg (virtual coverfloat_interface CFI);
     //BF_16 only has the exponent range to satisfy maxInt + 1
     //The largest unbiased BF_16 EXP = 2^8 - (127 + 2) = 127
     `ifdef COVER_BF16
-        B23_BF16_INT: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_int32, result_int32_fmt;
-        B23_BF16_UINT: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_uint32, result_uint32_fmt;
+        B23_BF16_INT: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_int32, result_int32_fmt, rounding_mode_all;
+        B23_BF16_UINT: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_uint32, result_uint32_fmt, rounding_mode_all;
         `ifdef COVER_LONG
-            B23_BF16_LONG: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_long64, result_long64_fmt;
-            B23_BF16_ULONG: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_ulong64, result_ulong64_fmt;
+            B23_BF16_LONG: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_long64, result_long64_fmt, rounding_mode_all;
+            B23_BF16_ULONG: cross BF16_input_fmt, FP2INT_op, BF16_proximity_to_max_ulong64, result_ulong64_fmt, rounding_mode_all;
         `endif
     `endif
 
@@ -196,33 +243,33 @@ covergroup B23_cg (virtual coverfloat_interface CFI);
     //F32 only has the exponent range to satisfy maxInt + 1, mantissa range lacks enough precision
     //The largest exponent is 2^8 - (127 + 2) = 127
     `ifdef COVER_F32
-        B23_F32_INT: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_int32, result_int32_fmt;
-        B23_F32_UINT: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_uint32, result_uint32_fmt;
+        B23_F32_INT: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_int32, result_int32_fmt, rounding_mode_all;
+        B23_F32_UINT: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_uint32, result_uint32_fmt, rounding_mode_all;
         `ifdef COVER_LONG
-            B23_F32_LONG: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_long64, result_long64_fmt;
-            B23_F32_ULONG: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_ulong64, result_ulong64_fmt;
+            B23_F32_LONG: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_long64, result_long64_fmt, rounding_mode_all;
+            B23_F32_ULONG: cross F32_input_fmt, FP2INT_op, F32_proximity_to_max_ulong64, result_ulong64_fmt, rounding_mode_all;
         `endif
     `endif
 
     //FMT_DOUBLE
-    //sufficient exponent and mantissa range to reach all values
+    //sufficient exponent and mantissa range to reach all values for 32-bit integer types, but not 64-bit integers
     `ifdef COVER_F64
-        B64_F64_INT: cross F64_input_fmt, FP2INT_op, proximity_to_max_int32, result_int32_fmt;
-        B23_F64_UINT: cross F64_input_fmt, FP2INT_op, proximity_to_max_uint32, result_uint32_fmt;
+        B64_F64_INT: cross F64_input_fmt, FP2INT_op, proximity_to_max_int32, result_int32_fmt, rounding_mode_all;
+        B23_F64_UINT: cross F64_input_fmt, FP2INT_op, proximity_to_max_uint32, result_uint32_fmt, rounding_mode_all;
         `ifdef COVER_LONG
-            B23_F64_LONG: cross F64_input_fmt, FP2INT_op, proximity_to_max_long64, result_long64_fmt;
-            B23_F64_ULONG: cross F64_input_fmt, FP2INT_op, proximity_to_max_ulong64, result_ulong64_fmt;
+            B23_F64_LONG: cross F64_input_fmt, FP2INT_op, F64_proximity_to_max_long64, result_long64_fmt, rounding_mode_all;
+            B23_F64_ULONG: cross F64_input_fmt, FP2INT_op, F64_proximity_to_max_ulong64, result_ulong64_fmt, rounding_mode_all;
         `endif
     `endif
 
     //FMT_QUAD
     //sufficient exponent and mantissa range to reach all values
     `ifdef COVER_F128
-        B23_F128_INT: cross F128_input_fmt, FP2INT_op, proximity_to_max_int32, result_int32_fmt;
-        B23_F128_UINT: cross F128_input_fmt, FP2INT_op, proximity_to_max_uint32, result_uint32_fmt;
+        B23_F128_INT: cross F128_input_fmt, FP2INT_op, proximity_to_max_int32, result_int32_fmt, rounding_mode_all;
+        B23_F128_UINT: cross F128_input_fmt, FP2INT_op, proximity_to_max_uint32, result_uint32_fmt, rounding_mode_all;
         `ifdef COVER_LONG
-            B23_F128_LONG: cross F128_input_fmt, FP2INT_op, proximity_to_max_long64, result_long64_fmt;
-            B23_F128_ULONG: cross F128_input_fmt, FP2INT_op, proximity_to_max_ulong64, result_ulong64_fmt;
+            B23_F128_LONG: cross F128_input_fmt, FP2INT_op, proximity_to_max_long64, result_long64_fmt, rounding_mode_all;
+            B23_F128_ULONG: cross F128_input_fmt, FP2INT_op, proximity_to_max_ulong64, result_ulong64_fmt, rounding_mode_all;
         `endif
     `endif
 

--- a/coverage/covergroups/B24.svh
+++ b/coverage/covergroups/B24.svh
@@ -49,31 +49,31 @@ covergroup B24_cg (virtual coverfloat_interface CFI);
     }
 
     // Sign coverpoints
-    F16_sign: coverpoint CFI.result[F16_SIGN_BIT] {
+    F16_sign: coverpoint CFI.a[F16_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    BF16_sign: coverpoint CFI.result[BF16_SIGN_BIT] {
+    BF16_sign: coverpoint CFI.a[BF16_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    F32_sign: coverpoint CFI.result[F32_SIGN_BIT] {
+    F32_sign: coverpoint CFI.a[F32_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    F64_sign: coverpoint CFI.result[F64_SIGN_BIT] {
+    F64_sign: coverpoint CFI.a[F64_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
     }
 
-    F128_sign: coverpoint CFI.result[F128_SIGN_BIT] {
+    F128_sign: coverpoint CFI.a[F128_SIGN_BIT] {
         type_option.weight = 0;
         bins pos = {0};
         bins neg = {1};
@@ -103,6 +103,11 @@ covergroup B24_cg (virtual coverfloat_interface CFI);
         type_option.weight = 0;
 
         bins int32 = {FMT_INT};
+    }
+
+    result_uint32_fmt: coverpoint CFI.resultFmt {
+        type_option.weight = 0;
+
         bins uint32 = {FMT_UINT};
     }
 
@@ -110,6 +115,11 @@ covergroup B24_cg (virtual coverfloat_interface CFI);
         type_option.weight = 0;
 
         bins int64 = {FMT_LONG};
+    }
+
+    result_ulong64_fmt: coverpoint CFI.resultFmt {
+        type_option.weight = 0;
+
         bins uint64 = {FMT_ULONG};
     }
 
@@ -117,40 +127,50 @@ covergroup B24_cg (virtual coverfloat_interface CFI);
     //FMT_HALF
     `ifdef COVER_F16
         B22_F16_INT: cross rounding_modes, F16_input_fmt, F16_sign, FP2INT_op, proximity_to_zero, result_int32_fmt;
+        B22_F16_UINT: cross rounding_modes, F16_input_fmt, FP2INT_op, proximity_to_zero, result_uint32_fmt;
         `ifdef COVER_LONG
             B22_F16_LONG: cross rounding_modes, F16_input_fmt, F16_sign, FP2INT_op, proximity_to_zero, result_long64_fmt;
+            B22_F16_ULONG: cross rounding_modes, F16_input_fmt, FP2INT_op, proximity_to_zero, result_ulong64_fmt;
         `endif
     `endif
 
     //FMT_BF16
     `ifdef COVER_BF16
         B22_BF16_INT: cross rounding_modes, BF16_input_fmt, BF16_sign, FP2INT_op, proximity_to_zero, result_int32_fmt;
+        B22_BF16_UINT: cross rounding_modes, BF16_input_fmt, FP2INT_op, proximity_to_zero, result_uint32_fmt;
         `ifdef COVER_LONG
             B22_BF16_LONG: cross rounding_modes, BF16_input_fmt, BF16_sign, FP2INT_op, proximity_to_zero, result_long64_fmt;
+            B22_BF16_ULONG: cross rounding_modes, BF16_input_fmt, FP2INT_op, proximity_to_zero, result_ulong64_fmt;
         `endif
     `endif
 
     //FMT_SINGLE
     `ifdef COVER_F32
         B22_F32_INT: cross rounding_modes, F32_input_fmt, F32_sign, FP2INT_op, proximity_to_zero, result_int32_fmt;
+        B22_F32_UINT: cross rounding_modes, F32_input_fmt, FP2INT_op, proximity_to_zero, result_uint32_fmt;
         `ifdef COVER_LONG
             B22_F32_LONG: cross rounding_modes, F32_input_fmt, F32_sign, FP2INT_op, proximity_to_zero, result_long64_fmt;
+            B22_F32_ULONG: cross rounding_modes, F32_input_fmt, FP2INT_op, proximity_to_zero, result_ulong64_fmt;
         `endif
     `endif
 
     //FMT_DOUBLE
     `ifdef COVER_F64
         B22_F64_INT: cross rounding_modes, F64_input_fmt, F64_sign, FP2INT_op, proximity_to_zero, result_int32_fmt;
+        B22_F64_UINT: cross rounding_modes, F64_input_fmt, FP2INT_op, proximity_to_zero, result_uint32_fmt;
         `ifdef COVER_LONG
             B22_F64_LONG: cross rounding_modes, F64_input_fmt, F64_sign, FP2INT_op, proximity_to_zero, result_long64_fmt;
+            B22_F64_ULONG: cross rounding_modes, F64_input_fmt, FP2INT_op, proximity_to_zero, result_ulong64_fmt;
         `endif
     `endif
 
     //FMT_QUAD
     `ifdef COVER_F128
         B22_F128_INT: cross rounding_modes, F128_input_fmt, F128_sign, FP2INT_op, proximity_to_zero, result_int32_fmt;
+        B22_F128_UINT: cross rounding_modes, F128_input_fmt, FP2INT_op, proximity_to_zero, result_uint32_fmt;
         `ifdef COVER_LONG
             B22_F128_LONG: cross rounding_modes, F128_input_fmt, F128_sign, FP2INT_op, proximity_to_zero, result_long64_fmt;
+            B22_F128_ULONG: cross rounding_modes, F128_input_fmt, FP2INT_op, proximity_to_zero, result_ulong64_fmt;
         `endif
     `endif
 


### PR DESCRIPTION
Fixes signs in all covergroups, and removes them from unsigned crosses. This also adds rounding modes to B23, and adds maxnorm-1 cases where there were only maxnorm+1 cases before. Though this isn't explicitly in Aharoni et al, it seems like their intention to have values on both sides of maxnorm. 