### PR TITLE
Prepare cover-float for use as a library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cover-float"
 version = "0.1.0"
-description = "Add your description here"
+description = "Test Generators With Coverage for the IBM Floating Point Tests"
 readme = "README.md"
 authors = [
     { name = "Corey Hickson", email = "chickson@hmc.edu" },
@@ -12,13 +12,12 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "rich==14.1.0",
+    "rich>=14.3.4",
     "sympy==1.14.0",
 ]
 
 [project.scripts]
-cover-float-reference = "cover_float.cli:main"
-cover-float-testgen = "cover_float.cli:testgen"
+cover-float-testgen = "cover_float.cli:main"
 
 [tool.scikit-build]
 minimum-version = "build-system.requires"

--- a/src/cover_float/__init__.py
+++ b/src/cover_float/__init__.py
@@ -13,4 +13,7 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-# This file has been intentionally left blank
+from cover_float.common.config import Config
+from cover_float.generate import generate
+
+__all__ = ["Config", "generate"]

--- a/src/cover_float/cli.py
+++ b/src/cover_float/cli.py
@@ -14,76 +14,17 @@
 # and limitations under the License.
 
 import argparse
-from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 from pathlib import Path
 
-from rich import print as rprint
-from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
-
-import cover_float.common.log as log
-import cover_float.testgen as tg
-from cover_float.common.config import Config
-from cover_float.common.util import SingleThreadedExecutor
+from cover_float import Config, generate
 
 
 def main() -> None:
     config = parse_args()
-    success = testgen(config)
+    success = generate(config)
 
     # Code 0 if successful
     exit(not success)
-
-
-def testgen(config: Config) -> bool:
-    single_thread = config.single_thread or (config.models is not None and len(config.models) < 2)
-
-    if single_thread:
-        executor = SingleThreadedExecutor()
-    else:
-        executor = ProcessPoolExecutor() if config.jobs is None else ProcessPoolExecutor(max_workers=config.jobs)
-
-    tg.discover_and_import_models()
-
-    with log.StatusReporter(config, disable=config.quiet) as logger, executor:
-        futures: list[Future[bool]] = []
-
-        if config.models is None:
-            for model in tg.GLOBAL_MODELS:
-                future = tg.GLOBAL_MODELS[model](config, logger, executor)
-                if future is not None:
-                    futures.append(future)
-        else:
-            for model in config.models:
-                if model in tg.GLOBAL_MODELS:
-                    future = tg.GLOBAL_MODELS[model](config, logger, executor)
-                    if future is not None:
-                        futures.append(future)
-
-        if len(futures) == 0:
-            if not config.silent:
-                display_name = "cover-float" if not config.models else ", ".join(config.models)
-                rprint(f"[bold green]✓ No work to be done for {display_name} [/]")
-            return True
-
-        success = True
-        if config.quiet and not config.silent:
-            with Progress(
-                TextColumn("{task.description}"),
-                BarColumn(),
-                MofNCompleteColumn(),
-                TimeElapsedColumn(),
-                transient=True,
-            ) as progress:
-                for future in progress.track(
-                    as_completed(futures), total=len(futures), description="[cyan]Generating Cover-Float Tests"
-                ):
-                    success &= future.result()
-            rprint(f"[bold green]✓ Generated {len(futures)} cover-float model(s)[/]")
-        else:
-            for future in as_completed(futures):
-                success &= future.result()
-
-        return success
 
 
 def parse_args() -> Config:

--- a/src/cover_float/cli.py
+++ b/src/cover_float/cli.py
@@ -14,40 +14,81 @@
 # and limitations under the License.
 
 import argparse
-import logging
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
+from rich import print as rprint
 
 import cover_float.common.log as log
 import cover_float.testgen as tg
-from cover_float.common.constants import config
 from cover_float.common.util import SingleThreadedExecutor
-from cover_float.reference import run_test_vector
+from cover_float.common.config import Config
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("input_file", type=str, help="Path to the input test vector file")
-    parser.add_argument("output_file", type=str, help="Path to the output cover vector file")
-    parser.add_argument(
-        "--suppress-error-check",
-        action="store_true",
-        help="Suppress error checking between expected and actual results",
-    )
-    args = parser.parse_args()
+    config = parse_args()
+    success = testgen(config)
 
-    with Path(args.input_file).open("r") as infile, Path(args.output_file).open("w") as outfile:
-        for line in infile:
-            line = line.strip()
-            if not line or line.startswith("//"):
-                continue  # Skip empty lines and comments
-            result = run_test_vector(line, args.suppress_error_check)
-            outfile.write(result)
+    # Code 0 if successful
+    exit(not success)
+    
+def testgen(config: Config) -> bool:
+    single_thread = config.single_thread or (config.models is not None and len(config.models) < 2)
 
+    if single_thread:
+        executor = SingleThreadedExecutor()
+    else:
+        executor = ProcessPoolExecutor() if config.jobs is None else ProcessPoolExecutor(max_workers=config.jobs)
+    
+    tg.discover_and_import_models()
 
-def testgen() -> None:
+    if args.quiet > 0:
+        logging.basicConfig(level=logging.ERROR)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    with log.StatusReporter(config, disable=config.quiet) as logger, executor:
+        futures: list[Future[bool]] = []
+
+        if config.models is None:
+            for model in tg.GLOBAL_MODELS:
+                future = tg.GLOBAL_MODELS[model](config, logger, executor)
+                if future is not None:
+                    futures.append(future)
+        else:
+            for model in config.models:
+                if model in tg.GLOBAL_MODELS:
+                    future = tg.GLOBAL_MODELS[model](config, logger, executor)
+                    if future is not None:
+                        futures.append(future)
+
+        if len(futures) == 0:
+            if not config.silent:
+                rprint(f"[bold green]✓ No work to be done for {'cover-float' if not config.models else ', '.join(config.models)} [/]")
+            return True
+
+        success = True
+        if config.quiet and not config.silent:
+            with Progress(
+                TextColumn("{task.description}"),
+                BarColumn(),
+                MofNCompleteColumn(),
+                TimeElapsedColumn(),
+                transient=True,
+            ) as progress:
+                for future in progress.track(
+                    as_completed(futures), total=len(futures), description="[cyan]Generating Cover-Float Tests"
+                ):
+                    success &= future.result()
+            rprint(f"[bold green]✓ Generated {len(futures)} cover-float model(s)[/]")
+        else:
+            for future in as_completed(futures):
+                success &= future.result()
+
+        return success
+
+def parse_args() -> Config:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--model",
@@ -75,54 +116,15 @@ def testgen() -> None:
 
     output_dir = Path(args.output_dir)
     single_thread = args.single_thread or (args.models is not None and len(args.models) < 2)
-    config.FULL_COVERAGE_TESTGEN = not args.partial_output
-    config.QUIET = args.quiet > 0
-    config.RELEASE = args.only_processed_vectors
-    if args.quiet > 0:
-        logging.basicConfig(level=logging.ERROR)
-    else:
-        logging.basicConfig(level=logging.INFO)
+    jobs = 1 if single_thread else args.jobs
 
-    if single_thread:
-        executor = SingleThreadedExecutor()
-    else:
-        executor = ProcessPoolExecutor() if args.jobs is None else ProcessPoolExecutor(max_workers=args.jobs)
-
-    with log.StatusReporter(disable=(args.quiet > 0)) as logger, executor:
-        futures: list[Future[bool]] = []
-
-        if args.models is None:
-            for model in tg.model.GLOBAL_MODELS:
-                future = tg.model.GLOBAL_MODELS[model](output_dir, logger, executor)
-                if future is not None:
-                    futures.append(future)
-        else:
-            for model in args.models:
-                if model in tg.model.GLOBAL_MODELS:
-                    future = tg.model.GLOBAL_MODELS[model](output_dir, logger, executor)
-                    if future is not None:
-                        futures.append(future)
-
-        if len(futures) == 0:
-            if args.quiet < 2:
-                print(f"No work to be done for {'cover-float' if not args.models else ', '.join(args.models)}")
-            return
-
-        success = True
-        if args.quiet == 1:
-            with Progress(
-                TextColumn("{task.description}"),
-                BarColumn(),
-                MofNCompleteColumn(),
-                TimeElapsedColumn(),
-            ) as progress:
-                for future in progress.track(
-                    as_completed(futures), total=len(futures), description="[cyan]Generating Cover-Float Tests"
-                ):
-                    success &= future.result()
-        else:
-            for future in as_completed(futures):
-                success &= future.result()
-
-        if not success:
-            exit(1)
+    return Config(
+        output_dir=output_dir,
+        full_coverage_testgen=not args.partial_output,
+        quiet=args.quiet > 0,
+        silent=args.quiet > 1,
+        release=args.only_processed_vectors,
+        jobs=jobs,
+        models=args.models,
+        single_thread=single_thread
+    )

--- a/src/cover_float/cli.py
+++ b/src/cover_float/cli.py
@@ -17,13 +17,13 @@ import argparse
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 from pathlib import Path
 
-from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
 from rich import print as rprint
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
 
 import cover_float.common.log as log
 import cover_float.testgen as tg
-from cover_float.common.util import SingleThreadedExecutor
 from cover_float.common.config import Config
+from cover_float.common.util import SingleThreadedExecutor
 
 
 def main() -> None:
@@ -32,7 +32,8 @@ def main() -> None:
 
     # Code 0 if successful
     exit(not success)
-    
+
+
 def testgen(config: Config) -> bool:
     single_thread = config.single_thread or (config.models is not None and len(config.models) < 2)
 
@@ -40,13 +41,8 @@ def testgen(config: Config) -> bool:
         executor = SingleThreadedExecutor()
     else:
         executor = ProcessPoolExecutor() if config.jobs is None else ProcessPoolExecutor(max_workers=config.jobs)
-    
-    tg.discover_and_import_models()
 
-    if args.quiet > 0:
-        logging.basicConfig(level=logging.ERROR)
-    else:
-        logging.basicConfig(level=logging.INFO)
+    tg.discover_and_import_models()
 
     with log.StatusReporter(config, disable=config.quiet) as logger, executor:
         futures: list[Future[bool]] = []
@@ -65,7 +61,8 @@ def testgen(config: Config) -> bool:
 
         if len(futures) == 0:
             if not config.silent:
-                rprint(f"[bold green]✓ No work to be done for {'cover-float' if not config.models else ', '.join(config.models)} [/]")
+                display_name = "cover-float" if not config.models else ", ".join(config.models)
+                rprint(f"[bold green]✓ No work to be done for {display_name} [/]")
             return True
 
         success = True
@@ -87,6 +84,7 @@ def testgen(config: Config) -> bool:
                 success &= future.result()
 
         return success
+
 
 def parse_args() -> Config:
     parser = argparse.ArgumentParser()
@@ -126,5 +124,5 @@ def parse_args() -> Config:
         release=args.only_processed_vectors,
         jobs=jobs,
         models=args.models,
-        single_thread=single_thread
+        single_thread=single_thread,
     )

--- a/src/cover_float/common/config.py
+++ b/src/cover_float/common/config.py
@@ -13,10 +13,17 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from cover_float.testgen.discover_models import discover_and_import_models
-from cover_float.testgen.model import GLOBAL_MODELS
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
 
-__all__ = [
-    "discover_and_import_models",
-    "GLOBAL_MODELS",
-]
+@dataclass
+class Config:
+    output_dir: Path
+    full_coverage_testgen: bool = True
+    quiet: bool = False
+    silent: bool = False
+    release: bool = False
+    jobs: int | None = None
+    models: list[str] | None = None
+    single_thread: bool = False

--- a/src/cover_float/common/config.py
+++ b/src/cover_float/common/config.py
@@ -14,8 +14,10 @@
 # and limitations under the License.
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
+
 
 @dataclass
 class Config:

--- a/src/cover_float/common/constants.py
+++ b/src/cover_float/common/constants.py
@@ -13,9 +13,7 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-# Commonly Use Constants
-
-from dataclasses import dataclass
+# Commonly Used Constants
 
 # Operation codes for test vectors
 
@@ -153,14 +151,3 @@ COVER_VECTOR_WIDTH_HEX = 302
 COVER_VECTOR_WIDTH_HEX_WITH_SEPARATORS = COVER_VECTOR_WIDTH_HEX + 12
 INTER_SIGNIFICAND_LENGTH = (3 * 112) + 4
 RFI_DECIMAL_POINT = INTER_SIGNIFICAND_LENGTH // 2
-
-
-@dataclass
-class Config:
-    FULL_COVERAGE_TESTGEN: bool = True
-    CACHE_DIR: str = "build/cache"
-    QUIET: bool = False
-    RELEASE: bool = False
-
-
-config = Config()

--- a/src/cover_float/common/log.py
+++ b/src/cover_float/common/log.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager
 from multiprocessing.connection import Connection
 from queue import Queue
 from types import TracebackType
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from rich import console
 from rich.logging import RichHandler
@@ -40,20 +40,35 @@ from rich.progress import (
     TextColumn,
 )
 
-STATUS_LEVEL_NUM = 25
-logging.addLevelName(STATUS_LEVEL_NUM, "STATUS")
+from cover_float.common.config import Config
+
+# Make the type checker happy
+if TYPE_CHECKING:
+    _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
+else:
+    _LoggerAdapter = logging.LoggerAdapter
 
 
-class ModelLogger(logging.Logger):
+class ModelAdapter(_LoggerAdapter):
     task_id: TaskID
     msg_queue: Queue[Any]
 
-    def __init__(self, name: str) -> None:
-        super().__init__(name)
+    def __init__(self, logger: logging.Logger, task_id: TaskID, msg_queue: Queue[Any]) -> None:
+        super().__init__(logger, {})
+        self.task_id = task_id
+        self.msg_queue = msg_queue
 
     def status(self, message: str, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
-        if self.isEnabledFor(STATUS_LEVEL_NUM):
-            self._log(STATUS_LEVEL_NUM, message, args, **kwargs)
+        if self.isEnabledFor(logging.INFO):
+            self.msg_queue.put(
+                {
+                    "action": "update",
+                    "args": [self.task_id],
+                    "kwargs": {
+                        "status": message,
+                    },
+                }
+            )
 
     @contextmanager
     def progress_bar(
@@ -70,19 +85,6 @@ class ModelLogger(logging.Logger):
             yield handle
         finally:
             handle.update(total=None, completed=0, m_of_n=False)
-
-
-logging.setLoggerClass(ModelLogger)
-
-
-class ExcludeStatusFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        return record.levelno != STATUS_LEVEL_NUM
-
-
-class OnlyStatusFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        return record.levelno == 25
 
 
 T = TypeVar("T")
@@ -171,7 +173,7 @@ class AsyncLoggingHandler(logging.handlers.QueueListener):
     def handle_progress_update(self, record: dict[Any, Any]) -> None:
         try:
             action = record["action"]
-            if self.level > STATUS_LEVEL_NUM:
+            if self.level > logging.INFO:
                 if action == "add_task":
                     task_id_pipe: Connection = record["pipe_end"]
                     task_id_pipe.send(-1)
@@ -192,9 +194,9 @@ class AsyncLoggingHandler(logging.handlers.QueueListener):
             elif action == "refresh":
                 self.reporter.progress.refresh()
             else:
-                logging.info(f"Failed to Log {record}")
+                logging.getLogger(__name__).info(f"Failed to Log {record}")
         except Exception:
-            logging.exception(f"Failed to Log {record}")
+            logging.getLogger(__name__).exception(f"Failed to Log {record}")
 
     def handle(self, record: logging.LogRecord | dict[Any, Any]) -> None:
         if isinstance(record, logging.LogRecord):
@@ -224,7 +226,7 @@ class ProgressAwareLogHandler(logging.Handler):
 
 
 class StatusReporter:
-    def __init__(self, *, disable: bool = False) -> None:
+    def __init__(self, config: Config, *, disable: bool = False) -> None:
         self.active_status_bars: dict[str, TaskID] = {}
         self.progress = Progress(
             SpinnerColumn(),
@@ -242,9 +244,9 @@ class StatusReporter:
         # This is the actual handler that prints to console
         self.rich_handler = ProgressAwareLogHandler(self.progress)
         self.queue_listener = AsyncLoggingHandler(
-            self, self.logging_queue, logging.getLogger().level, self.rich_handler
+            self, self.logging_queue, log_level_from_config(config), self.rich_handler
         )
-        logging.getLogger().addHandler(logging.handlers.QueueHandler(self.logging_queue))
+        logging.getLogger(__name__).addHandler(logging.handlers.QueueHandler(self.logging_queue))
 
         # This keeps all of the refreshes in one thread, eliminating all race conditions
         self._refresh_thread: threading.Timer = threading.Timer(0.1, self._reset_refresh_timer)
@@ -302,3 +304,7 @@ class StatusReporter:
         # This can be a race condition, if there is logging still in the queue
         # so we must enqueue the destruction
         self.logging_queue.put({"action": "remove_task", "args": [model_name], "kwargs": {}})
+
+
+def log_level_from_config(config: Config) -> int:
+    return logging.ERROR if config.quiet else logging.INFO

--- a/src/cover_float/generate.py
+++ b/src/cover_float/generate.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2025-26 Harvey Mudd College
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, any work distributed under the
+# License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+
+from rich import print as rprint
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
+
+import cover_float.common.log as log
+import cover_float.testgen as tg
+from cover_float.common.config import Config
+from cover_float.common.util import SingleThreadedExecutor
+
+
+def generate(config: Config) -> bool:
+    single_thread = config.single_thread or (config.models is not None and len(config.models) < 2)
+
+    if single_thread:
+        executor = SingleThreadedExecutor()
+    else:
+        executor = ProcessPoolExecutor() if config.jobs is None else ProcessPoolExecutor(max_workers=config.jobs)
+
+    tg.discover_and_import_models()
+
+    with log.StatusReporter(config, disable=config.quiet) as logger, executor:
+        futures: list[Future[bool]] = []
+
+        if config.models is None:
+            for model in tg.GLOBAL_MODELS:
+                future = tg.GLOBAL_MODELS[model](config, logger, executor)
+                if future is not None:
+                    futures.append(future)
+        else:
+            for model in config.models:
+                if model in tg.GLOBAL_MODELS:
+                    future = tg.GLOBAL_MODELS[model](config, logger, executor)
+                    if future is not None:
+                        futures.append(future)
+
+        if len(futures) == 0:
+            if not config.silent:
+                display_name = "cover-float" if not config.models else ", ".join(config.models)
+                rprint(f"[bold green]✓ No work to be done for {display_name} [/]")
+            return True
+
+        success = True
+        if config.quiet and not config.silent:
+            with Progress(
+                TextColumn("{task.description}"),
+                BarColumn(),
+                MofNCompleteColumn(),
+                TimeElapsedColumn(),
+                transient=True,
+            ) as progress:
+                for future in progress.track(
+                    as_completed(futures), total=len(futures), description="[cyan]Generating Cover-Float Tests"
+                ):
+                    success &= future.result()
+            rprint(f"[bold green]✓ Generated {len(futures)} cover-float model(s)[/]")
+        else:
+            for future in as_completed(futures):
+                success &= future.result()
+
+        return success

--- a/src/cover_float/generate.py
+++ b/src/cover_float/generate.py
@@ -13,6 +13,7 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
+import multiprocessing
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 
 from rich import print as rprint
@@ -25,14 +26,16 @@ from cover_float.common.util import SingleThreadedExecutor
 
 
 def generate(config: Config) -> bool:
-    single_thread = config.single_thread or (config.models is not None and len(config.models) < 2)
+    tg.discover_and_import_models()
 
+    single_thread = config.single_thread or (config.models is not None and len(config.models) < 2)
     if single_thread:
         executor = SingleThreadedExecutor()
     else:
-        executor = ProcessPoolExecutor() if config.jobs is None else ProcessPoolExecutor(max_workers=config.jobs)
-
-    tg.discover_and_import_models()
+        initializer = None
+        if multiprocessing.get_start_method() != "fork":  # Default on linux for python < 3.14
+            initializer = tg.discover_and_import_models
+        executor = ProcessPoolExecutor(max_workers=config.jobs, initializer=initializer)
 
     with log.StatusReporter(config, disable=config.quiet) as logger, executor:
         futures: list[Future[bool]] = []

--- a/src/cover_float/reference/impl.py
+++ b/src/cover_float/reference/impl.py
@@ -17,8 +17,8 @@ from typing import TextIO
 
 import cover_float._reference
 import cover_float._unmodified_reference
-from cover_float.common.constants import TEST_VECTOR_WIDTH_HEX_WITH_SEPARATORS
 from cover_float.common.config import Config
+from cover_float.common.constants import TEST_VECTOR_WIDTH_HEX_WITH_SEPARATORS
 
 
 def run_and_store_test_vector(test_vector: str, test_file: TextIO, cover_file: TextIO, config: Config) -> None:

--- a/src/cover_float/reference/impl.py
+++ b/src/cover_float/reference/impl.py
@@ -17,24 +17,25 @@ from typing import TextIO
 
 import cover_float._reference
 import cover_float._unmodified_reference
-from cover_float.common.constants import TEST_VECTOR_WIDTH_HEX_WITH_SEPARATORS, config
+from cover_float.common.constants import TEST_VECTOR_WIDTH_HEX_WITH_SEPARATORS
+from cover_float.common.config import Config
 
 
-def run_and_store_test_vector(test_vector: str, test_file: TextIO, cover_file: TextIO) -> None:
+def run_and_store_test_vector(test_vector: str, test_file: TextIO, cover_file: TextIO, config: Config) -> None:
     """Run test_vector through coverfloat and store both the test vector and cover vector"""
 
     cover_vector = cover_float._reference.run_test_vector(test_vector)
 
     generated_test_vector = cover_vector[:TEST_VECTOR_WIDTH_HEX_WITH_SEPARATORS]
     test_file.write(generated_test_vector + "\n")
-    if not config.RELEASE:
+    if not config.release:
         cover_file.write(cover_vector.strip() + "\n")
 
 
-def store_cover_vector(cover_vector: str, test_file: TextIO, cover_file: TextIO) -> None:
+def store_cover_vector(cover_vector: str, test_file: TextIO, cover_file: TextIO, config: Config) -> None:
     generated_test_vector = cover_vector[:TEST_VECTOR_WIDTH_HEX_WITH_SEPARATORS]
     test_file.write(generated_test_vector + "\n")
-    if not config.RELEASE:
+    if not config.release:
         cover_file.write(cover_vector.strip() + "\n")
 
 

--- a/src/cover_float/scripts/parse_testvectors.py
+++ b/src/cover_float/scripts/parse_testvectors.py
@@ -28,10 +28,9 @@ Currently supports
 - Flags: 'x' if a flag is raised and '' if none
 """
 
-import logging
 import time
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 import cover_float.common.log as log
 from cover_float.reference import run_test_vector_unmodified, verify_test_vector
@@ -291,9 +290,7 @@ def format_output(parsed: dict[str, Any]) -> str:
     return f"{base} -> {parsed['result']} ({parsed['res_fmt_name']}){flags}"
 
 
-def auto_parse(model_name: str, output_dir: str) -> None:
-    logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger(model_name))
-
+def auto_parse(model_name: str, output_dir: str, logger: log.ModelAdapter) -> None:
     input_path = Path(output_dir) / "testvectors" / f"{model_name}_tv.txt"
     output_path = Path(output_dir) / "readable" / f"{model_name}_parsed.txt"
 

--- a/src/cover_float/scripts/postprocess.py
+++ b/src/cover_float/scripts/postprocess.py
@@ -19,12 +19,11 @@
 from __future__ import annotations
 
 import csv
-import logging
 import os
 import pathlib
 import time
 from dataclasses import dataclass
-from typing import TextIO, cast
+from typing import TextIO
 
 import cover_float.common.log as log
 from cover_float.common import constants
@@ -106,13 +105,12 @@ NO_ROUNDING_MODE_OPS = ["fclass", "feq", "fle", "flt", "fmax", "fmin", "fsgnj", 
 
 def postprocess_testvectors(
     model: str,
+    logger: log.ModelAdapter,
     test_vector_location: pathlib.Path,
     processed_vectors_dir: pathlib.Path,
     readable_vectors_dir: pathlib.Path,
     config: Config,
 ) -> None:
-    logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger(model))
-
     test_vector_file = test_vector_location / f"{model}_tv.txt"
     readable_vectors_file = (
         readable_vectors_dir / f"{model}_parsed.txt" if not config.release else pathlib.Path(os.devnull)

--- a/src/cover_float/scripts/postprocess.py
+++ b/src/cover_float/scripts/postprocess.py
@@ -28,6 +28,7 @@ from typing import TextIO, cast
 
 import cover_float.common.log as log
 from cover_float.common import constants
+from cover_float.common.config import Config
 from cover_float.common.util import unpack_test_vector
 from cover_float.reference import run_test_vector_unmodified, verify_test_vector
 from cover_float.scripts.parse_testvectors import format_output, parse_test_vector
@@ -108,19 +109,20 @@ def postprocess_testvectors(
     test_vector_location: pathlib.Path,
     processed_vectors_dir: pathlib.Path,
     readable_vectors_dir: pathlib.Path,
+    config: Config,
 ) -> None:
     logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger(model))
 
     test_vector_file = test_vector_location / f"{model}_tv.txt"
     readable_vectors_file = (
-        readable_vectors_dir / f"{model}_parsed.txt" if not constants.config.RELEASE else pathlib.Path(os.devnull)
+        readable_vectors_dir / f"{model}_parsed.txt" if not config.release else pathlib.Path(os.devnull)
     )
     processed_vectors: dict[str, tuple[csv.DictWriter[str], TextIO]] = {}
     total = 0
     non_riscv = 0
 
     file_size = test_vector_file.stat().st_size
-    if not constants.config.RELEASE:
+    if not config.release:
         readable_vectors_file.parent.mkdir(parents=True, exist_ok=True)
 
     with (
@@ -134,7 +136,7 @@ def postprocess_testvectors(
         for line in test_vectors.readlines():
             parsed = parse_test_vector(line)
             if parsed:
-                if not constants.config.RELEASE:
+                if not config.release:
                     readable_vectors.write(format_output(parsed) + "\n")
 
                 if not verify_test_vector(line):

--- a/src/cover_float/testgen/B1.py
+++ b/src/cover_float/testgen/B1.py
@@ -18,6 +18,7 @@ from typing import TextIO, cast
 
 import cover_float.common.constants as const
 import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
@@ -294,7 +295,7 @@ BASIC_TYPES = {
 }
 
 
-def write1SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int]) -> None:
+def write1SrcTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, choices: list[int]) -> None:
 
     rm = const.ROUND_NEAR_EVEN
 
@@ -307,11 +308,11 @@ def write1SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int]
         for i in choices:
             val = BASIC_TYPES[fmt][i]
             run_and_store_test_vector(
-                f"{op}_{rm}_{val}_{32 * '0'}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f
+                f"{op}_{rm}_{val}_{32 * '0'}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f, config
             )
 
 
-def writeCvtTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int]) -> None:
+def writeCvtTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, choices: list[int]) -> None:
 
     rm = const.ROUND_NEAR_EVEN
 
@@ -327,11 +328,14 @@ def writeCvtTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int])
                 for i in choices:
                     val = BASIC_TYPES[fmt][i]
                     run_and_store_test_vector(
-                        f"{op}_{rm}_{val}_{32 * '0'}_{32 * '0'}_{fmt}_{32 * '0'}_{resultFmt}_00", test_f, cover_f
+                        f"{op}_{rm}_{val}_{32 * '0'}_{32 * '0'}_{fmt}_{32 * '0'}_{resultFmt}_00",
+                        test_f,
+                        cover_f,
+                        config,
                     )
 
 
-def write2SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int]) -> None:
+def write2SrcTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, choices: list[int]) -> None:
 
     rm = const.ROUND_NEAR_EVEN
 
@@ -343,11 +347,11 @@ def write2SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int]
             for j in choices:
                 val2 = BASIC_TYPES[fmt][j]
                 run_and_store_test_vector(
-                    f"{op}_{rm}_{val1}_{val2}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f
+                    f"{op}_{rm}_{val1}_{val2}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f, config
                 )
 
 
-def write3SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int]) -> None:
+def write3SrcTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, choices: list[int]) -> None:
 
     rm = const.ROUND_NEAR_EVEN
 
@@ -361,11 +365,11 @@ def write3SrcTests(test_f: TextIO, cover_f: TextIO, fmt: str, choices: list[int]
                 for k in choices:
                     val3 = BASIC_TYPES[fmt][k]
                     run_and_store_test_vector(
-                        f"{op}_{rm}_{val1}_{val2}_{val3}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f
+                        f"{op}_{rm}_{val1}_{val2}_{val3}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f, config
                     )
 
 
-def writeResultTests(test_f: TextIO, cover_f: TextIO, fmt: str, full_coverage: bool) -> None:
+def writeResultTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, full_coverage: bool) -> None:
     if not full_coverage:
         return
 
@@ -376,23 +380,23 @@ def writeResultTests(test_f: TextIO, cover_f: TextIO, fmt: str, full_coverage: b
     mantissa = 0
     a = generate_float(0, exp, mantissa, fmt)
     tv = generate_test_vector(const.OP_SQRT, a, 0, 0, fmt, fmt)
-    run_and_store_test_vector(tv, test_f, cover_f)
+    run_and_store_test_vector(tv, test_f, cover_f, config)
 
     # Generate a +1.5 result (input is 2.25)
     exp = 1
     mantissa = 1 << (const.MANTISSA_BITS[fmt] - 3)
     a = generate_float(0, exp, mantissa, fmt)
     tv = generate_test_vector(const.OP_SQRT, a, 0, 0, fmt, fmt)
-    run_and_store_test_vector(tv, test_f, cover_f)
+    run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B1")
-def main(test_vectors: TextIO, cover_vectors: TextIO) -> None:
-    choices = list(range(len(BASIC_TYPES[const.FMT_SINGLE]))) if const.config.FULL_COVERAGE_TESTGEN else minimal_set
+def main(config: Config, test_vectors: TextIO, cover_vectors: TextIO) -> None:
+    choices = list(range(len(BASIC_TYPES[const.FMT_SINGLE]))) if config.full_coverage_testgen else minimal_set
 
     for fmt in const.FLOAT_FMTS:
-        write1SrcTests(test_vectors, cover_vectors, fmt, choices)
-        write2SrcTests(test_vectors, cover_vectors, fmt, choices)
-        write3SrcTests(test_vectors, cover_vectors, fmt, choices)
-        writeCvtTests(test_vectors, cover_vectors, fmt, choices)
-        writeResultTests(test_vectors, cover_vectors, fmt, const.config.FULL_COVERAGE_TESTGEN)
+        write1SrcTests(test_vectors, cover_vectors, config, fmt, choices)
+        write2SrcTests(test_vectors, cover_vectors, config, fmt, choices)
+        write3SrcTests(test_vectors, cover_vectors, config, fmt, choices)
+        writeCvtTests(test_vectors, cover_vectors, config, fmt, choices)
+        writeResultTests(test_vectors, cover_vectors, config, fmt, config.full_coverage_testgen)

--- a/src/cover_float/testgen/B1.py
+++ b/src/cover_float/testgen/B1.py
@@ -13,17 +13,13 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-import logging
-from typing import TextIO, cast
+from typing import TextIO
 
 import cover_float.common.constants as const
-import cover_float.common.log as log
 from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector
 from cover_float.reference import run_and_store_test_vector
-from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
+from cover_float.testgen.model import get_model_logger, register_model
 
 SRC1_OPS = [const.OP_SQRT, const.OP_CLASS, const.OP_RFI]
 
@@ -303,7 +299,7 @@ def write1SrcTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, ch
     print("// 1 source operations, all basic type input combinations", file=test_f)
     # print("//", file=f)
     for op in SRC1_OPS:
-        logger.status(f"OP IS: {op}")
+        get_model_logger("B1").status(f"OP IS: {op}")
         # print(f"FMT IS: {fmt}")
         for i in choices:
             val = BASIC_TYPES[fmt][i]
@@ -320,7 +316,7 @@ def writeCvtTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, cho
     print("// 1 source convert operations, all basic type input and result format combinations", file=test_f)
     # print("//", file=f)
     for op in CVT_OPS:
-        logger.status(f"OP IS: {op}")
+        get_model_logger("B1").status(f"OP IS: {op}")
         # print(f"FMT IS: {fmt}")
         fmts = const.FLOAT_FMTS if op == const.OP_CFF else const.INT_FMTS
         for resultFmt in fmts:
@@ -341,7 +337,7 @@ def write2SrcTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, ch
 
     print("// 2 source operations, all basic type input combinations", file=test_f)
     for op in SRC2_OPS:
-        logger.status(f"OP IS: {op}")
+        get_model_logger("B1").status(f"OP IS: {op}")
         for i in choices:
             val1 = BASIC_TYPES[fmt][i]
             for j in choices:
@@ -357,7 +353,7 @@ def write3SrcTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str, ch
 
     print("// 3 source operations, all basic type input combinations", file=test_f)
     for op in SRC3_OPS:
-        logger.status(f"OP IS: {op}")
+        get_model_logger("B1").status(f"OP IS: {op}")
         for i in choices:
             val1 = BASIC_TYPES[fmt][i]
             for j in choices:

--- a/src/cover_float/testgen/B10.py
+++ b/src/cover_float/testgen/B10.py
@@ -21,6 +21,7 @@ import random
 from random import seed
 from typing import TextIO
 
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     BIASED_EXP,
     EXPONENT_BITS,
@@ -44,7 +45,7 @@ def decimalComponentsToHex(fmt: str, biased_exp: int) -> str:
     return h_complete
 
 
-def innerTest(test_f: TextIO, cover_f: TextIO, op: str) -> None:
+def innerTest(test_f: TextIO, cover_f: TextIO, config: Config, op: str) -> None:
     for fmt in FLOAT_FMTS:
         p = MANTISSA_BITS[fmt] + 1
         min_exp = BIASED_EXP[fmt][0]
@@ -65,6 +66,7 @@ def innerTest(test_f: TextIO, cover_f: TextIO, op: str) -> None:
                 f"{op}_{ROUND_NEAR_EVEN}_{complete_a}_{complete_b}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00",
                 test_f,
                 cover_f,
+                config,
             )
 
             b_exp += 1  # Final statement, increments 1 over
@@ -81,12 +83,13 @@ def innerTest(test_f: TextIO, cover_f: TextIO, op: str) -> None:
                 f"{op}_{ROUND_NEAR_EVEN}_{complete_a}_{complete_b}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00",
                 test_f,
                 cover_f,
+                config,
             )
 
             b_exp -= 1  # Final statement, decrements 1 under
 
 
-def outerTest(isTestOne: bool, test_f: TextIO, cover_f: TextIO, op: str) -> None:
+def outerTest(isTestOne: bool, test_f: TextIO, cover_f: TextIO, config: Config, op: str) -> None:
     for fmt in FLOAT_FMTS:
         p = MANTISSA_BITS[fmt] + 1
         min_exp = BIASED_EXP[fmt][0]
@@ -109,18 +112,20 @@ def outerTest(isTestOne: bool, test_f: TextIO, cover_f: TextIO, op: str) -> None
                 f"{op}_{ROUND_NEAR_EVEN}_{complete_a}_{complete_b}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00",
                 test_f,
                 cover_f,
+                config,
             )
         else:
             run_and_store_test_vector(
                 f"{op}_{ROUND_NEAR_EVEN}_{complete_b}_{complete_a}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00",
                 test_f,
                 cover_f,
+                config,
             )
 
 
 @register_model("B10")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for op in [OP_ADD, OP_SUB]:
-        outerTest(True, test_f, cover_f, op)  # Test #1
-        innerTest(test_f, cover_f, op)  # Test #2
-        outerTest(False, test_f, cover_f, op)  # Test #3
+        outerTest(True, test_f, cover_f, config, op)  # Test #1
+        innerTest(test_f, cover_f, config, op)  # Test #2
+        outerTest(False, test_f, cover_f, config, op)  # Test #3

--- a/src/cover_float/testgen/B11.py
+++ b/src/cover_float/testgen/B11.py
@@ -28,6 +28,7 @@ import random
 from pathlib import Path
 from typing import TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 import cover_float.common.log as log
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
@@ -52,7 +53,7 @@ def interesting_shift_ranges(low_shifts: int, shifts_from_edge: int, fmt: str) -
 
 
 def interesting_tests(
-    sigs: list[int], interesting_shifts: list[int], fmt: str, test_f: TextIO, cover_f: TextIO
+    sigs: list[int], interesting_shifts: list[int], fmt: str, test_f: TextIO, cover_f: TextIO, config: Config
 ) -> None:
     random.seed(reproducible_hash("b11 interesting " + fmt))
     exp_min, exp_max = constants.BIASED_EXP[fmt]
@@ -72,11 +73,11 @@ def interesting_tests(
                 float2 = generate_float(sign, exp2, sig2, fmt)
 
                 tv = generate_test_vector(op, float1, float2, 0, fmt, fmt, random.choice(constants.ROUNDING_MODES))
-                run_and_store_test_vector(tv, test_f, cover_f)
+                run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 def uninteresting_tests(
-    sigs: list[int], interesting_shifts: list[int], fmt: str, test_f: TextIO, cover_f: TextIO
+    sigs: list[int], interesting_shifts: list[int], fmt: str, test_f: TextIO, cover_f: TextIO, config: Config
 ) -> None:
     random.seed(reproducible_hash("b11 uninteresting " + fmt))
 
@@ -110,11 +111,11 @@ def uninteresting_tests(
             float2 = generate_float(sign, exp2, sig2, fmt)
 
             tv = generate_test_vector(op, float1, float2, 0, fmt, fmt, random.choice(constants.ROUNDING_MODES))
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B11")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
         seed = reproducible_hash(fmt + "b11")
         random.seed(seed)
@@ -133,11 +134,11 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
             sig_gen = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], "b11" + fmt)
             sigs = [int(sig, 2) for sig in sig_gen.generate(generated_coverage)]
 
-            if constants.config.FULL_COVERAGE_TESTGEN:
+            if config.full_coverage_testgen:
                 interesting_shifts = interesting_shift_ranges(2, 2, fmt)
             else:
                 interesting_shifts = interesting_shift_ranges(0, 0, fmt)
 
-            logger.status(f"Generating {fmt} Tests")
-            interesting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)
-            uninteresting_tests(sigs, interesting_shifts, fmt, test_f, cover_f)
+            get_model_logger("B11").status(f"Generating {fmt} Tests")
+            interesting_tests(sigs, interesting_shifts, fmt, test_f, cover_f, config)
+            uninteresting_tests(sigs, interesting_shifts, fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B11.py
+++ b/src/cover_float/testgen/B11.py
@@ -23,20 +23,16 @@
 # the interesting shift ranges, so short and long shifts: [-3, 3], [nf, nf-3], and [-nf, -nf+3]
 
 import itertools
-import logging
 import random
 from pathlib import Path
-from typing import TextIO, cast
+from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.B9 import B9SignificandGenerator
-from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B11"))
+from cover_float.testgen.model import get_model_logger, register_model
 
 B11_OPS = [constants.OP_ADD, constants.OP_SUB]
 
@@ -120,7 +116,7 @@ def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
         seed = reproducible_hash(fmt + "b11")
         random.seed(seed)
 
-        logger.status(f"Generating {fmt} Sigs & Shifts")
+        get_model_logger("B11").status(f"Generating {fmt} Sigs & Shifts")
         bins_path = Path(
             "coverage",
             "covergroups",

--- a/src/cover_float/testgen/B12.py
+++ b/src/cover_float/testgen/B12.py
@@ -25,6 +25,7 @@ import random
 from random import seed
 from typing import TextIO
 
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     BIASED_EXP,
     EXPONENT_BITS,
@@ -48,15 +49,15 @@ def decimalComponentsToHex(fmt: str, sign: int, biased_exp: int, mantissa: int) 
     return f"{int(bits, 2):032X}"
 
 
-def writeAdd(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO) -> None:
+def writeAdd(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     run_and_store_test_vector(
-        f"{OP_ADD}_{ROUND_NEAR_EVEN}_{a_hex}_{b_hex}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f
+        f"{OP_ADD}_{ROUND_NEAR_EVEN}_{a_hex}_{b_hex}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f, config
     )
 
 
-def writeSub(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO) -> None:
+def writeSub(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     run_and_store_test_vector(
-        f"{OP_SUB}_{ROUND_NEAR_EVEN}_{a_hex}_{b_hex}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f
+        f"{OP_SUB}_{ROUND_NEAR_EVEN}_{a_hex}_{b_hex}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00", test_f, cover_f, config
     )
 
 
@@ -119,7 +120,7 @@ def makeCarryMantissas(fmt: str) -> tuple[int, int]:
     return a_m, b_m
 
 
-def makeTestVectors(fmt: str, d: int, operation: str, test_f: TextIO, cover_f: TextIO) -> None:
+def makeTestVectors(fmt: str, d: int, operation: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     m = MANTISSA_BITS[fmt]
     p = m + 1
     min_exp, max_exp = BIASED_EXP[fmt]
@@ -164,25 +165,25 @@ def makeTestVectors(fmt: str, d: int, operation: str, test_f: TextIO, cover_f: T
     a_hex = decimalComponentsToHex(fmt, a_sign, a_exp, a_m)
     b_hex = decimalComponentsToHex(fmt, b_sign, b_exp, b_m)
 
-    write_fn(fmt, a_hex, b_hex, test_f, cover_f)
+    write_fn(fmt, a_hex, b_hex, test_f, cover_f, config)
 
 
-def CancellationTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def CancellationTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     p = MANTISSA_BITS[fmt] + 1
 
     for d in range(-p, 2):  # [-p, +1]
         hashval = reproducible_hash(OP_ADD + fmt + "b12")
         seed(hashval)
-        makeTestVectors(fmt, d, "add", test_f, cover_f)
+        makeTestVectors(fmt, d, "add", test_f, cover_f, config)
         hashval = reproducible_hash(OP_SUB + fmt + "b12")
         seed(hashval)
-        makeTestVectors(fmt, d, "sub", test_f, cover_f)
+        makeTestVectors(fmt, d, "sub", test_f, cover_f, config)
 
 
 @register_model("B12")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     test_f.write("// Cancellation tests\n")
     test_f.write("// Operations: ADD, SUB\n")
 
     for fmt in FLOAT_FMTS:
-        CancellationTests(test_f, cover_f, fmt)
+        CancellationTests(test_f, cover_f, config, fmt)

--- a/src/cover_float/testgen/B13.py
+++ b/src/cover_float/testgen/B13.py
@@ -24,6 +24,7 @@ import random
 from random import seed
 from typing import TextIO
 
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     EXPONENT_BITS,
     FLOAT_FMTS,
@@ -46,19 +47,21 @@ def decimalComponentsToHex(fmt: str, sign: int, biased_exp: int, mantissa: int) 
     return f"{int(bits, 2):032X}"
 
 
-def writeAdd(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO) -> None:
+def writeAdd(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     run_and_store_test_vector(
         f"{OP_ADD}_{ROUND_NEAR_EVEN}_{a_hex}_{b_hex}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00",
         test_f,
         cover_f,
+        config,
     )
 
 
-def writeSub(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO) -> None:
+def writeSub(fmt: str, a_hex: str, b_hex: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     run_and_store_test_vector(
         f"{OP_SUB}_{ROUND_NEAR_EVEN}_{a_hex}_{b_hex}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00",
         test_f,
         cover_f,
+        config,
     )
 
 
@@ -121,7 +124,9 @@ def makeCarryMantissas(fmt: str, m_shifts: int) -> tuple[int, int]:
     return a_m, b_m
 
 
-def makeTestVectors(fmt: str, d: int, leading_zeros: int, operation: str, test_f: TextIO, cover_f: TextIO) -> None:
+def makeTestVectors(
+    fmt: str, d: int, leading_zeros: int, operation: str, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     m = MANTISSA_BITS[fmt]
     p = m + 1
 
@@ -173,10 +178,10 @@ def makeTestVectors(fmt: str, d: int, leading_zeros: int, operation: str, test_f
     a_hex = decimalComponentsToHex(fmt, a_sign, a_exp, a_m)
     b_hex = decimalComponentsToHex(fmt, b_sign, b_exp, b_m)
 
-    write_fn(fmt, a_hex, b_hex, test_f, cover_f)
+    write_fn(fmt, a_hex, b_hex, test_f, cover_f, config)
 
 
-def SubnormCancellationTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def SubnormCancellationTests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     m = MANTISSA_BITS[fmt]
     p = m + 1
 
@@ -185,22 +190,22 @@ def SubnormCancellationTests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             if d == 0 or d == 1:
                 if leading_zeros != (m - 1):
                     seed(reproducible_hash(f"{fmt}_b13_add_{d}_{leading_zeros}"))
-                    makeTestVectors(fmt, d, leading_zeros, "add", test_f, cover_f)
+                    makeTestVectors(fmt, d, leading_zeros, "add", test_f, cover_f, config)
 
                     seed(reproducible_hash(f"{fmt}_b13_sub_{d}_{leading_zeros}"))
-                    makeTestVectors(fmt, d, leading_zeros, "sub", test_f, cover_f)
+                    makeTestVectors(fmt, d, leading_zeros, "sub", test_f, cover_f, config)
             else:
                 seed(reproducible_hash(f"{fmt}_b13_add_{d}_{leading_zeros}"))
-                makeTestVectors(fmt, d, leading_zeros, "add", test_f, cover_f)
+                makeTestVectors(fmt, d, leading_zeros, "add", test_f, cover_f, config)
 
                 seed(reproducible_hash(f"{fmt}_b13_sub_{d}_{leading_zeros}"))
-                makeTestVectors(fmt, d, leading_zeros, "sub", test_f, cover_f)
+                makeTestVectors(fmt, d, leading_zeros, "sub", test_f, cover_f, config)
 
 
 @register_model("B13")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     test_f.write("// B13 Cancellation + Subnormal Tests\n")
     test_f.write("// ADD, SUB\n")
 
     for fmt in FLOAT_FMTS:
-        SubnormCancellationTests(test_f, cover_f, fmt)
+        SubnormCancellationTests(test_f, cover_f, config, fmt)

--- a/src/cover_float/testgen/B14.py
+++ b/src/cover_float/testgen/B14.py
@@ -26,6 +26,7 @@ import logging
 import random
 from typing import TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as const
 import cover_float.common.log as log
 from cover_float.common.util import reproducible_hash
@@ -46,7 +47,7 @@ def decimalComponentsToHex(fmt: str, sign: int, biased_exp: int, mantissa: int) 
     return h_complete
 
 
-def generate_b14_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def generate_b14_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     p = const.MANTISSA_BITS[fmt] + 1
     min_u, max_u = const.UNBIASED_EXP[fmt]
     bias = const.BIAS[fmt]
@@ -112,10 +113,11 @@ def generate_b14_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 f"{op}_{const.ROUND_NEAR_EVEN}_{hex_a}_{hex_b}_{hex_c}_{fmt}_{32 * '0'}_{fmt}_00",
                 test_f,
                 cover_f,
+                config,
             )
 
 
 @register_model("B14")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in const.FLOAT_FMTS:
-        generate_b14_tests(test_f, cover_f, fmt)
+        generate_b14_tests(test_f, cover_f, config, fmt)

--- a/src/cover_float/testgen/B14.py
+++ b/src/cover_float/testgen/B14.py
@@ -22,18 +22,14 @@
 # result and the addend in a fused multiply-add (FMA) operation. The shift is
 # defined as S = unbiased_exp(A*B) - unbiased_exp(C).
 
-import logging
 import random
-from typing import TextIO, cast
+from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as const
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B14"))
 
 OPS = [const.OP_FMADD, const.OP_FMSUB, const.OP_FNMADD, const.OP_FNMSUB]
 

--- a/src/cover_float/testgen/B15.py
+++ b/src/cover_float/testgen/B15.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 import cover_float.common.log as log
 from cover_float.common.util import (
@@ -632,6 +633,7 @@ def interesting_tests(
     fmt: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
 ) -> None:
     random.seed(reproducible_hash(f"b15 {fmt} interesting"))
 
@@ -670,7 +672,7 @@ def interesting_tests(
                 tv = generate_test_vector(
                     op, mul_float1, mul_float2, add_float, fmt, fmt, random.choice(constants.ROUNDING_MODES)
                 )
-                run_and_store_test_vector(tv, test_f, cover_f)
+                run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 def uninteresting_tests(
@@ -680,6 +682,7 @@ def uninteresting_tests(
     fmt: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
 ) -> None:
     random.seed(reproducible_hash(f"b15 {fmt} uninteresting"))
 
@@ -731,7 +734,7 @@ def uninteresting_tests(
             tv = generate_test_vector(
                 op, mul_float1, mul_float2, add_float, fmt, fmt, random.choice(constants.ROUNDING_MODES)
             )
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 def interesting_shift_ranges(low_shifts: int, shifts_from_edge: int, fmt: str) -> list[int]:
@@ -746,9 +749,7 @@ def interesting_shift_ranges(low_shifts: int, shifts_from_edge: int, fmt: str) -
 
 
 @register_model("B15")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    cache_dir = Path(constants.config.CACHE_DIR)
-
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
         hashval = reproducible_hash(fmt + "b15")
         random.seed(hashval)
@@ -759,23 +760,18 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
         add_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_special_sigs.svh"
         mul_sigs_path = bins_path / f"B15_{constants.FMT_TO_STRING[fmt]}_prod_special_sigs.svh"
         with add_sigs_path.open("w") as add_sigs_file, mul_sigs_path.open("w") as mul_sigs_file:
-            cache_file = cache_dir / f"b15-{fmt}-cache.pkl"
-
             logger.status(f"Generating {fmt} Sigs & Shifts")
             b9_sig_gen = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b15")
             b9_sigs = [int(sig, 2) for sig in b9_sig_gen.generate(add_sigs_file)]
 
             b15_sig_gen = B15SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt, fmt + "b15")
-            b15_sigs = [
-                (int(sig1, 2), int(sig2, 2))
-                for sig1, sig2 in b15_sig_gen.generate(mul_sigs_file, cache_file_path=cache_file)
-            ]
+            b15_sigs = [(int(sig1, 2), int(sig2, 2)) for sig1, sig2 in b15_sig_gen.generate(mul_sigs_file)]
 
-            if constants.config.FULL_COVERAGE_TESTGEN:
+            if config.full_coverage_testgen:
                 interesting_shifts = interesting_shift_ranges(2, 2, fmt)
             else:
                 interesting_shifts = interesting_shift_ranges(0, 0, fmt)
 
             logger.status(f"Generating {fmt} Tests")
-            interesting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)
-            uninteresting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f)
+            interesting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f, config)
+            uninteresting_tests(b15_sigs, b9_sigs, interesting_shifts, fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B15.py
+++ b/src/cover_float/testgen/B15.py
@@ -18,16 +18,14 @@
 from __future__ import annotations
 
 import itertools
-import logging
 import pickle
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, BinaryIO, TextIO, cast
+from typing import TYPE_CHECKING, BinaryIO, TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import (
     bezout_inverse,
     factors_to_bit_width,
@@ -37,9 +35,7 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.B9 import B9SignificandGenerator
-from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B15"))
+from cover_float.testgen.model import get_model_logger, register_model
 
 if TYPE_CHECKING:
     # This block is seen by Pyright but ignored at runtime
@@ -405,7 +401,9 @@ class B15SignificandGenerator:
 
         hits = 0
         for attempt in range(10000):
-            logger.status(f"Generating {self.fmt} Sparse Zeros: Generated: {hits}/10, Attempts: {attempt}")
+            get_model_logger("B15").status(
+                f"Generating {self.fmt} Sparse Zeros: Generated: {hits}/10, Attempts: {attempt}"
+            )
             target = (1 << (2 * self.nf + 2)) - 1
             for _ in range(min(8, self.nf // 2)):
                 p2 = random.randint(1, 2 * self.nf)
@@ -467,11 +465,10 @@ class B15SignificandGenerator:
 
             sig1_pattern = "10" * (teeth_length) + "1" * internal_ones_count + "01" * teeth_length
             if len(sig1_pattern) > self.nf + 1:
-                logger.exception(
+                raise ValueError(
                     f"Invalid Arrangement for Long Run of Ones, offset={offset}, run_length={run_length} "
                     f"Generated Sig1: {sig1_pattern}, length={len(sig1_pattern)}"
                 )
-                continue
 
             sig1_pattern += "0" * (self.nf + 1 - len(sig1_pattern))
             sig1 = int(sig1_pattern, 2)
@@ -535,7 +532,7 @@ class B15SignificandGenerator:
                         self.sigs.append(B15Significand(sig1, sig2, target))
                         break
                 else:
-                    logger.exception("Long Run Zeros Failed (factoring)")
+                    raise ValueError("Long Run Zeros Failed (factoring)")
             elif run_length + offset - self.nf < 20:
                 # We can generally get away with the stochastic search here (limitation still exists for nf=112)
                 best = 2 * self.nf, 0, 0
@@ -573,7 +570,7 @@ class B15SignificandGenerator:
                         best = score, sig1, sig2
 
                 if best[0] != 0:
-                    logger.exception(f"Long Run Zeros Failed for {self.fmt}")
+                    raise ValueError(f"Long Run Zeros Failed for {self.fmt}")
 
                 sig1 = bin(best[1])[3:]
                 sig2 = bin(best[2])[3:]
@@ -581,6 +578,7 @@ class B15SignificandGenerator:
                 self.sigs.append(B15Significand(sig1, sig2, res))
 
     def generate(self, file: TextIO, *, cache_file_path: Path | None = None) -> list[tuple[str, str]]:
+        logger = get_model_logger("B15")
         if cache_file_path and cache_file_path.exists():
             logger.info(f"Retrieving Cached Significands from {cache_file_path}")
             with cache_file_path.open("rb") as cache:
@@ -750,6 +748,7 @@ def interesting_shift_ranges(low_shifts: int, shifts_from_edge: int, fmt: str) -
 
 @register_model("B15")
 def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    logger = get_model_logger("B15")
     for fmt in constants.FLOAT_FMTS:
         hashval = reproducible_hash(fmt + "b15")
         random.seed(hashval)

--- a/src/cover_float/testgen/B16.py
+++ b/src/cover_float/testgen/B16.py
@@ -5,13 +5,11 @@ Created: 4/28/2026
 Last Modified: 4/28/2026
 """
 
-import logging
 import random
 from dataclasses import dataclass
 from random import seed
-from typing import TextIO, cast
+from typing import TextIO
 
-import cover_float.common.log as log
 from cover_float.common.config import Config
 from cover_float.common.constants import (
     BIAS,
@@ -33,8 +31,6 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B16"))
 
 OPS = [OP_FMADD, OP_FMSUB, OP_FNMADD, OP_FNMSUB]
 SOLVER_OPS = {

--- a/src/cover_float/testgen/B16.py
+++ b/src/cover_float/testgen/B16.py
@@ -8,11 +8,11 @@ Last Modified: 4/28/2026
 import logging
 import random
 from dataclasses import dataclass
-from pathlib import Path
 from random import seed
 from typing import TextIO, cast
 
 import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     BIAS,
     EXPONENT_BITS,
@@ -72,9 +72,10 @@ class FloatFormat:
 
 
 class B16Generator:
-    def __init__(self, fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+    def __init__(self, fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
         self.f = FloatFormat.from_name(fmt)
         self.test_f, self.cover_f = test_f, cover_f
+        self.config = config
 
     def get_op_details(self, op: str, a: str, b: str, c: str) -> tuple[int, int]:
         """Helper to get actual product exp and final result exp."""
@@ -84,7 +85,7 @@ class B16Generator:
 
     def store(self, op: str, a: str, b: str, c: str) -> None:
         v = generate_test_vector(op, int(a, 16), int(b, 16), int(c, 16), self.f.name, self.f.name)
-        run_and_store_test_vector(v, self.test_f, self.cover_f)
+        run_and_store_test_vector(v, self.test_f, self.cover_f, self.config)
 
     def get_random_split(self, target_exp: int) -> tuple[int, int]:
         """Splits a target product exponent into two valid operand exponents."""
@@ -218,17 +219,13 @@ class B16Generator:
 
 
 @register_model("B16")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    with (
-        Path("./tests/testvectors/B16_tv.txt").open("w") as tf,
-        Path("./tests/covervectors/B16_cv.txt").open("w") as cf,
-    ):
-        for fmt_name in FLOAT_FMTS:
-            gen = B16Generator(fmt_name, tf, cf)
-            for d in range(-(2 * gen.f.p + 1), 2):
-                retries = 15
-                for op in OPS:
-                    seed(reproducible_hash(f"{fmt_name}_b16_{d}_{op}"))
-                    for _ in range(retries):
-                        if gen.generate(d, op):
-                            break
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    for fmt_name in FLOAT_FMTS:
+        gen = B16Generator(fmt_name, test_f, cover_f, config)
+        for d in range(-(2 * gen.f.p + 1), 2):
+            retries = 15
+            for op in OPS:
+                seed(reproducible_hash(f"{fmt_name}_b16_{d}_{op}"))
+                for _ in range(retries):
+                    if gen.generate(d, op):
+                        break

--- a/src/cover_float/testgen/B17.py
+++ b/src/cover_float/testgen/B17.py
@@ -17,13 +17,11 @@
 
 from __future__ import annotations
 
-import logging
 import random
-from typing import TextIO, cast
+from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import (
     bezout_inverse,
     generate_float,
@@ -32,9 +30,7 @@ from cover_float.common.util import (
     unpack_test_vector,
 )
 from cover_float.reference import run_test_vector, store_cover_vector
-from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B17"))
+from cover_float.testgen.model import get_model_logger, register_model
 
 
 def mul_sigs_with_trailing(
@@ -278,7 +274,7 @@ def generate(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
         for op in [constants.OP_FMADD, constants.OP_FMSUB, constants.OP_FNMADD, constants.OP_FNMSUB]:
             random.seed(reproducible_hash(f"B17 {fmt} {op}"))
-            with logger.progress_bar(f"{fmt} Subnorm Exp for {op}", show_m_of_n=True) as pbar:
+            with get_model_logger("B17").progress_bar(f"{fmt} Subnorm Exp for {op}", show_m_of_n=True) as pbar:
                 for subnorm_exp in pbar.track(range(-constants.MANTISSA_BITS[fmt] + 1, 1)):
                     min_cancel = -(2 * constants.MANTISSA_BITS[fmt] + 1)
                     max_cancel = 1 if subnorm_exp != -constants.MANTISSA_BITS[fmt] + 1 else 0

--- a/src/cover_float/testgen/B17.py
+++ b/src/cover_float/testgen/B17.py
@@ -21,6 +21,7 @@ import logging
 import random
 from typing import TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 import cover_float.common.log as log
 from cover_float.common.util import (
@@ -58,7 +59,9 @@ def mul_sigs_with_trailing(
     return (0, 0)
 
 
-def generate_case(op: str, fmt: str, subnorm_exp: int, cancellation: int, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_case(
+    op: str, fmt: str, subnorm_exp: int, cancellation: int, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     # cancellation = INTERM_X - max(ADDEND, MULTIPLICATION_RESULT)
     # In practice, this means that we need an addend and a multiplication result with the same exponent
     # Thus, max(ADDEND, MULTIPLICATION_RESULT) = INTERM_X - cancellation
@@ -262,7 +265,7 @@ def generate_case(op: str, fmt: str, subnorm_exp: int, cancellation: int, test_f
             f"B17 Generated Wrong Cancellation: Expected: {cancellation}, actual: {actual_cancellation}"
         )
 
-        store_cover_vector(cv, test_f, cover_f)
+        store_cover_vector(cv, test_f, cover_f, config)
         return
 
     raise ValueError(
@@ -271,7 +274,7 @@ def generate_case(op: str, fmt: str, subnorm_exp: int, cancellation: int, test_f
 
 
 @register_model("B17")
-def generate(test_f: TextIO, cover_f: TextIO) -> None:
+def generate(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
         for op in [constants.OP_FMADD, constants.OP_FMSUB, constants.OP_FNMADD, constants.OP_FNMSUB]:
             random.seed(reproducible_hash(f"B17 {fmt} {op}"))
@@ -281,4 +284,4 @@ def generate(test_f: TextIO, cover_f: TextIO) -> None:
                     max_cancel = 1 if subnorm_exp != -constants.MANTISSA_BITS[fmt] + 1 else 0
 
                     for cancellation in range(min_cancel, max_cancel + 1):
-                        generate_case(op, fmt, subnorm_exp, cancellation, test_f, cover_f)
+                        generate_case(op, fmt, subnorm_exp, cancellation, test_f, cover_f, config)

--- a/src/cover_float/testgen/B18.py
+++ b/src/cover_float/testgen/B18.py
@@ -4,6 +4,7 @@
 import random
 from typing import TextIO
 
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     EXPONENT_BIAS,
     EXPONENT_BITS,
@@ -90,7 +91,7 @@ def getRandomInt(min_exp: int, max_exp: int, sign: str, precision: str) -> str:
     return generate_FP(precision, sign, exp, mantissa_str)
 
 
-def genUnderflowTests(test_f: TextIO, cover_f: TextIO) -> None:
+def genUnderflowTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for precision in FLOAT_FMTS:
         min_exp = UNBIASED_EXP[precision][0] + 1
         max_exp = UNBIASED_EXP[precision][1] - 1
@@ -103,10 +104,11 @@ def genUnderflowTests(test_f: TextIO, cover_f: TextIO) -> None:
                     f"{operation}_{rm}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00",
                     test_f,
                     cover_f,
+                    config,
                 )
 
 
-def genOverflowTests(test_f: TextIO, cover_f: TextIO) -> None:
+def genOverflowTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for precision in FLOAT_FMTS:
         rounding_mode = random.choice(ROUNDING_MODES)
 
@@ -131,6 +133,7 @@ def genOverflowTests(test_f: TextIO, cover_f: TextIO) -> None:
                     f"{operation}_{rm}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00",
                     test_f,
                     cover_f,
+                    config,
                 )
 
 
@@ -148,7 +151,7 @@ def get_fma_signs(operation: str) -> tuple[int, int]:
     return op_mul_sign, op_add_sign
 
 
-def lsbGuardStickyTests(test_f: TextIO, cover_f: TextIO) -> None:
+def lsbGuardStickyTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     rounding_mode = random.choice(ROUNDING_MODES)
     for precision in FLOAT_FMTS:
         for grs_int in range(0, 8):
@@ -156,7 +159,10 @@ def lsbGuardStickyTests(test_f: TextIO, cover_f: TextIO) -> None:
                 mul_sign, add_sign = get_fma_signs(operation)
                 a, b, c = get_fp_values(precision, f"{grs_int:03b}", mul_sign, add_sign)
                 run_and_store_test_vector(
-                    f"{operation}_{rounding_mode}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+                    f"{operation}_{rounding_mode}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00",
+                    test_f,
+                    cover_f,
+                    config,
                 )
 
 
@@ -286,8 +292,8 @@ def generate_exact_factors(lsb: int, guard: int, m_bits: int) -> tuple[int, int]
 
 
 @register_model("B18")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     random.seed(reproducible_hash("B18"))
-    genUnderflowTests(test_f, cover_f)
-    genOverflowTests(test_f, cover_f)
-    lsbGuardStickyTests(test_f, cover_f)
+    genUnderflowTests(test_f, cover_f, config)
+    genOverflowTests(test_f, cover_f, config)
+    lsbGuardStickyTests(test_f, cover_f, config)

--- a/src/cover_float/testgen/B19.py
+++ b/src/cover_float/testgen/B19.py
@@ -26,6 +26,7 @@ import random
 from typing import TextIO
 
 import cover_float.common.constants as const
+from cover_float.common.config import Config
 from cover_float.common.util import reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
@@ -70,6 +71,7 @@ def _emit(
     op: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
     s1: int,
     bexp1: int,
     frac1: int,
@@ -83,6 +85,7 @@ def _emit(
         f"{op}_{const.ROUND_NEAR_EVEN}_{hex1}_{hex2}_{32 * '0'}_{fmt}_{32 * '0'}_{fmt}_00",
         test_f,
         cover_f,
+        config,
     )
 
 
@@ -91,7 +94,7 @@ def _emit(
 # ---------------------------------------------------------------------------
 
 
-def _case_1_normal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_1_normal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 1: +/-Normal x +/-Normal.  9 cells x 4 sign combos = 36."""
     min_nb, max_nb, frac_max = _fmt_params(fmt)
     Z = 0  # all zeros
@@ -107,7 +110,7 @@ def _case_1_normal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) 
         bexp2 = _any_exp(fmt)
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, max_nb, frac1, s2, bexp2, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, max_nb, frac1, s2, bexp2, frac2)
                 count += 1
 
     # Exp <: bexp1 = min_norm_bexp, bexp2 = any exp
@@ -119,7 +122,7 @@ def _case_1_normal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) 
         bexp2 = _any_exp(fmt)
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, min_nb, frac1, s2, bexp2, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, min_nb, frac1, s2, bexp2, frac2)
                 count += 1
 
     # Exp =: bexp1 = bexp2 = any exp (same value)
@@ -131,13 +134,13 @@ def _case_1_normal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) 
         bexp = _any_exp(fmt)
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, bexp, frac1, s2, bexp, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, bexp, frac1, s2, bexp, frac2)
                 count += 1
 
     return count
 
 
-def _case_2_normal_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_2_normal_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 2: +/-Normal x +/-SubNormal.  3 cells x 4 sign combos = 12."""
     af = _any_frac(fmt)
     bexp1 = _any_exp(fmt)
@@ -152,13 +155,13 @@ def _case_2_normal_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextI
     ]:
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, bexp1, frac1, s2, 0, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, bexp1, frac1, s2, 0, frac2)
                 count += 1
 
     return count
 
 
-def _case_3_subnormal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_3_subnormal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 3: +/-SubNormal x +/-Normal.  3 cells x 4 sign combos = 12."""
     _, _, frac_max = _fmt_params(fmt)
     af = _any_frac(fmt)
@@ -174,13 +177,13 @@ def _case_3_subnormal_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextI
     ]:
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, 0, frac1, s2, bexp2, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, 0, frac1, s2, bexp2, frac2)
                 count += 1
 
     return count
 
 
-def _case_4_subnormal_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_4_subnormal_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 4: +/-SubNormal x +/-SubNormal.  5 cells x 4 sign combos = 20."""
     _, _, frac_max = _fmt_params(fmt)
     af = _any_frac(fmt)
@@ -202,13 +205,13 @@ def _case_4_subnormal_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: Te
     ]:
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, 0, frac1, s2, 0, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, 0, frac1, s2, 0, frac2)
                 count += 1
 
     return count
 
 
-def _case_5_zero_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_5_zero_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 5: +/-Zero x +/-Normal.  2 cells x 4 sign combos = 8."""
     af = _any_frac(fmt)
     bexp2 = _any_exp(fmt)
@@ -220,13 +223,13 @@ def _case_5_zero_x_normal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) ->
     ]:
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, 0, 0, s2, bexp2, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, 0, 0, s2, bexp2, frac2)
                 count += 1
 
     return count
 
 
-def _case_6_normal_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_6_normal_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 6: +/-Normal x +/-Zero.  2 cells x 4 sign combos = 8."""
     af = _any_frac(fmt)
     bexp1 = _any_exp(fmt)
@@ -238,13 +241,13 @@ def _case_6_normal_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) ->
     ]:
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, bexp1, frac1, s2, 0, 0)
+                _emit(fmt, op, test_f, cover_f, config, s1, bexp1, frac1, s2, 0, 0)
                 count += 1
 
     return count
 
 
-def _case_7_zero_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_7_zero_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 7: +/-Zero x +/-Subnormal.  1 cell x 4 sign combos = 4."""
     af = _any_frac(fmt)
     count = 0
@@ -256,13 +259,13 @@ def _case_7_zero_x_subnormal(fmt: str, op: str, test_f: TextIO, cover_f: TextIO)
     ]:
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, 0, 0, s2, 0, frac2)
+                _emit(fmt, op, test_f, cover_f, config, s1, 0, 0, s2, 0, frac2)
                 count += 1
 
     return count
 
 
-def _case_8_subnormal_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_8_subnormal_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 8: +/-Subnormal x +/-Zero.  1 cell x 4 sign combos = 4."""
     af = _any_frac(fmt)
     count = 0
@@ -274,18 +277,18 @@ def _case_8_subnormal_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO)
     ]:
         for s1 in (0, 1):
             for s2 in (0, 1):
-                _emit(fmt, op, test_f, cover_f, s1, 0, frac1, s2, 0, 0)
+                _emit(fmt, op, test_f, cover_f, config, s1, 0, frac1, s2, 0, 0)
                 count += 1
 
     return count
 
 
-def _case_9_zero_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> int:
+def _case_9_zero_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO, config: Config) -> int:
     """Case 9: +/-Zero x +/-Zero.  1 cell x 4 sign combos = 4."""
     count = 0
     for s1 in (0, 1):
         for s2 in (0, 1):
-            _emit(fmt, op, test_f, cover_f, s1, 0, 0, s2, 0, 0)
+            _emit(fmt, op, test_f, cover_f, config, s1, 0, 0, s2, 0, 0)
             count += 1
     return count
 
@@ -295,22 +298,22 @@ def _case_9_zero_x_zero(fmt: str, op: str, test_f: TextIO, cover_f: TextIO) -> i
 # ---------------------------------------------------------------------------
 
 
-def generate_b19_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def generate_b19_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     """Generate all B19 test vectors for a given format."""
     for op in OPS:
         random.seed(reproducible_hash(f"B19 {fmt} {op}"))
-        _c1 = _case_1_normal_x_normal(fmt, op, test_f, cover_f)
-        _c2 = _case_2_normal_x_subnormal(fmt, op, test_f, cover_f)
-        _c3 = _case_3_subnormal_x_normal(fmt, op, test_f, cover_f)
-        _c4 = _case_4_subnormal_x_subnormal(fmt, op, test_f, cover_f)
-        _c5 = _case_5_zero_x_normal(fmt, op, test_f, cover_f)
-        _c6 = _case_6_normal_x_zero(fmt, op, test_f, cover_f)
-        _c7 = _case_7_zero_x_subnormal(fmt, op, test_f, cover_f)
-        _c8 = _case_8_subnormal_x_zero(fmt, op, test_f, cover_f)
-        _c9 = _case_9_zero_x_zero(fmt, op, test_f, cover_f)
+        _c1 = _case_1_normal_x_normal(fmt, op, test_f, cover_f, config)
+        _c2 = _case_2_normal_x_subnormal(fmt, op, test_f, cover_f, config)
+        _c3 = _case_3_subnormal_x_normal(fmt, op, test_f, cover_f, config)
+        _c4 = _case_4_subnormal_x_subnormal(fmt, op, test_f, cover_f, config)
+        _c5 = _case_5_zero_x_normal(fmt, op, test_f, cover_f, config)
+        _c6 = _case_6_normal_x_zero(fmt, op, test_f, cover_f, config)
+        _c7 = _case_7_zero_x_subnormal(fmt, op, test_f, cover_f, config)
+        _c8 = _case_8_subnormal_x_zero(fmt, op, test_f, cover_f, config)
+        _c9 = _case_9_zero_x_zero(fmt, op, test_f, cover_f, config)
 
 
 @register_model("B19")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in const.FLOAT_FMTS:
-        generate_b19_tests(test_f, cover_f, fmt)
+        generate_b19_tests(test_f, cover_f, config, fmt)

--- a/src/cover_float/testgen/B2.py
+++ b/src/cover_float/testgen/B2.py
@@ -20,12 +20,11 @@ Created:         April 8, 2026
 Last Edited:     April 10, 2026
 """
 
-import logging
 import random
 from random import seed
-from typing import Callable, TextIO, cast
+from typing import Callable, TextIO
 
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     BIAS,
     BIASED_EXP,
@@ -42,7 +41,6 @@ from cover_float.common.constants import (
     OP_SQRT,
     OP_SUB,
 )
-from cover_float.common.config import Config
 from cover_float.common.util import (
     decimal_components_to_hex,
     generate_test_vector,
@@ -51,8 +49,6 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B2"))
 
 ZERO = "0" * 32
 

--- a/src/cover_float/testgen/B2.py
+++ b/src/cover_float/testgen/B2.py
@@ -42,6 +42,7 @@ from cover_float.common.constants import (
     OP_SQRT,
     OP_SUB,
 )
+from cover_float.common.config import Config
 from cover_float.common.util import (
     decimal_components_to_hex,
     generate_test_vector,
@@ -184,7 +185,7 @@ class Generator:
 
 
 @register_model("B2")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in FLOAT_FMTS:
         gen = Generator(fmt)
 
@@ -207,29 +208,29 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
 
                     a, b, c = gen.gen_add(desired, base_e, maxnorm, sign)
                     vec = generate_test_vector(OP_ADD, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                    run_and_store_test_vector(vec, test_f, cover_f)
+                    run_and_store_test_vector(vec, test_f, cover_f, config)
 
                     a, b, c = gen.gen_sub(desired, base_e, maxnorm, sign)
                     vec = generate_test_vector(OP_SUB, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                    run_and_store_test_vector(vec, test_f, cover_f)
+                    run_and_store_test_vector(vec, test_f, cover_f, config)
 
                     a, b, c = gen.gen_mul(desired, maxnorm, sign)
                     vec = generate_test_vector(OP_MUL, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                    run_and_store_test_vector(vec, test_f, cover_f)
+                    run_and_store_test_vector(vec, test_f, cover_f, config)
 
                     a, b, c = gen.gen_div(desired, maxnorm, sign)
                     vec = generate_test_vector(OP_DIV, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                    run_and_store_test_vector(vec, test_f, cover_f)
+                    run_and_store_test_vector(vec, test_f, cover_f, config)
 
                     if sign == 0 and base == "One":
                         a, b, c = gen.gen_sqrt(desired)
                         vec = generate_test_vector(OP_SQRT, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                        run_and_store_test_vector(vec, test_f, cover_f)
+                        run_and_store_test_vector(vec, test_f, cover_f, config)
 
                     for op in [OP_FMADD, OP_FMSUB, OP_FNMADD, OP_FNMSUB]:
                         a, b, c = gen.gen_fma(op, desired, base_e, maxnorm)
                         vec = generate_test_vector(op, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                        run_and_store_test_vector(vec, test_f, cover_f)
+                        run_and_store_test_vector(vec, test_f, cover_f, config)
 
             # for -0 cases
             if base == "Zero":
@@ -238,9 +239,9 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
                 seed(reproducible_hash(f"{fmt}_zero_add_1"))
                 a, b, c = gen.gen_add(desired, 0, False, 1)
                 vec = generate_test_vector(OP_ADD, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                run_and_store_test_vector(vec, test_f, cover_f)
+                run_and_store_test_vector(vec, test_f, cover_f, config)
 
                 seed(reproducible_hash(f"{fmt}_zero_sub_1"))
                 a, b, c = gen.gen_sub(desired, 0, False, 1)
                 vec = generate_test_vector(OP_SUB, int(a, 16), int(b, 16), int(c, 16), fmt, fmt)
-                run_and_store_test_vector(vec, test_f, cover_f)
+                run_and_store_test_vector(vec, test_f, cover_f, config)

--- a/src/cover_float/testgen/B20.py
+++ b/src/cover_float/testgen/B20.py
@@ -15,19 +15,16 @@
 
 # B20 (rwolk@g.hmc.edu)
 
-import logging
 import math
 import random
-from typing import TextIO, cast
+from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
 from cover_float.reference import run_and_store_test_vector, run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
 
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
 
 def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # Generally, we want to look for two significands, sig1 and sig2 where
@@ -61,10 +58,9 @@ def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config
         # Extract Number of trailing zeros for verification
         generated_trailing_zeros = len(bin(res)) - len(bin(res).rstrip("0"))
         if generated_trailing_zeros != trailing_zeros:
-            logger.exception(
+            raise ValueError(
                 f"Failed to Generate A Div Result for format {fmt} with exactly {trailing_zeros} trailing_zeros"
             )
-            continue
 
         exp1, exp2 = random.randint(min_exp, max_exp), random.randint(min_exp, max_exp)
         while not min_exp < exp1 - exp2 < max_exp:
@@ -120,10 +116,9 @@ def generate_sqrt_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Confi
         mantissa |= 1 << nf
 
         if mantissa != answer:
-            logger.exception(
+            raise ValueError(
                 f"Failed to Generate a SQRT Value for format: {fmt} and number of trailing zeros: {trailing_zeros}"
             )
-            continue
 
         store_cover_vector(result, test_f, cover_f, config)
 

--- a/src/cover_float/testgen/B20.py
+++ b/src/cover_float/testgen/B20.py
@@ -20,6 +20,7 @@ import math
 import random
 from typing import TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 import cover_float.common.log as log
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
@@ -28,8 +29,7 @@ from cover_float.testgen.model import register_model
 
 logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
 
-
-def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # Generally, we want to look for two significands, sig1 and sig2 where
     # when reduced into lowest terms, sig2 only has factors of two. Now, when
     # sig2 is 2^k, we have nf - k trailing zeros.
@@ -74,10 +74,10 @@ def generate_div_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         f2 = generate_float(random.randint(0, 1), exp2, s2 & ((1 << nf) - 1), fmt)
         tv = generate_test_vector(constants.OP_DIV, f1, f2, 0, fmt, fmt, random.choice(constants.ROUNDING_MODES))
 
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
-def generate_sqrt_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_sqrt_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # We are looking for exact square root answers that are exact and have an exact number of trailing zeros
     # This makes the approach very easy: We generate the answers, then make sure they fit into a float
     # when squared. Clearly, because the multiplication result is 2.2nf, and the number of trailing zeros
@@ -125,11 +125,11 @@ def generate_sqrt_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             )
             continue
 
-        store_cover_vector(result, test_f, cover_f)
+        store_cover_vector(result, test_f, cover_f, config)
 
 
 @register_model("B20")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
-        generate_div_tests(fmt, test_f, cover_f)
-        generate_sqrt_tests(fmt, test_f, cover_f)
+        generate_div_tests(fmt, test_f, cover_f, config)
+        generate_sqrt_tests(fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B21.py
+++ b/src/cover_float/testgen/B21.py
@@ -20,6 +20,7 @@ import random
 from random import seed
 from typing import TextIO
 
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     BIASED_EXP,
     EXPONENT_BITS,
@@ -94,7 +95,7 @@ def getInput(precision: str, input_key: str, hashString: str) -> str:
     return generate_FP(precision, str(random.randint(0, 1)), exp, mantissa)
 
 
-def genTests(test_f: TextIO, cover_f: TextIO) -> None:
+def genTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for rounding_mode in ROUNDING_MODES:
         for precision in FLOAT_FMTS:
             for op in [OP_DIV, OP_REM]:
@@ -106,9 +107,10 @@ def genTests(test_f: TextIO, cover_f: TextIO) -> None:
                             f"{op}_{rounding_mode}_{a}_{b}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
                             test_f,
                             cover_f,
+                            config,
                         )
 
 
 @register_model("B21")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    genTests(test_f, cover_f)
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    genTests(test_f, cover_f, config)

--- a/src/cover_float/testgen/B22.py
+++ b/src/cover_float/testgen/B22.py
@@ -20,12 +20,13 @@ import random
 from typing import TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
 
 
-def generate_B22(test_f: TextIO, cover_f: TextIO) -> None:
+def generate_B22(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # Seed the RNG for deterministic mantissas
     seed = reproducible_hash("B22")
     random.seed(seed)
@@ -51,7 +52,7 @@ def generate_B22(test_f: TextIO, cover_f: TextIO) -> None:
                 fraction = random.getrandbits(nf)
                 f_low = generate_float(sign, e_low, fraction, src_fmt)
                 tv = generate_test_vector(constants.OP_CFI, f_low, 0, 0, src_fmt, dest_fmt, constants.ROUND_NEAR_EVEN)
-                run_and_store_test_vector(tv, test_f, cover_f)
+                run_and_store_test_vector(tv, test_f, cover_f, config)
 
                 # Mid region: -3 <= E <= int_width + 3
                 # For each integer exponent in this range
@@ -62,7 +63,7 @@ def generate_B22(test_f: TextIO, cover_f: TextIO) -> None:
                     tv = generate_test_vector(
                         constants.OP_CFI, f_mid, 0, 0, src_fmt, dest_fmt, constants.ROUND_NEAR_EVEN
                     )
-                    run_and_store_test_vector(tv, test_f, cover_f)
+                    run_and_store_test_vector(tv, test_f, cover_f, config)
 
                 # High region: E > int_width + 3
                 # Pick E_High = int_width + 4, only if reachable
@@ -73,9 +74,9 @@ def generate_B22(test_f: TextIO, cover_f: TextIO) -> None:
                     tv = generate_test_vector(
                         constants.OP_CFI, f_high, 0, 0, src_fmt, dest_fmt, constants.ROUND_NEAR_EVEN
                     )
-                    run_and_store_test_vector(tv, test_f, cover_f)
+                    run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B22")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    generate_B22(test_f, cover_f)
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    generate_B22(test_f, cover_f, config)

--- a/src/cover_float/testgen/B23.py
+++ b/src/cover_float/testgen/B23.py
@@ -19,6 +19,7 @@
 from typing import TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
@@ -96,7 +97,7 @@ def f16_neighborhood(nf: int) -> list[tuple[int, int]]:
     ]
 
 
-def generate_B23(test_f: TextIO, cover_f: TextIO) -> None:
+def generate_B23(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for src_fmt in constants.FLOAT_FMTS:
         nf = constants.MANTISSA_BITS[src_fmt]
 
@@ -119,9 +120,9 @@ def generate_B23(test_f: TextIO, cover_f: TextIO) -> None:
                     for sign in (0, 1):
                         f = generate_float(sign, unbiased_exp, mantissa, src_fmt)
                         tv = generate_test_vector(constants.OP_CFI, f, 0, 0, src_fmt, dest_fmt, rm)
-                        run_and_store_test_vector(tv, test_f, cover_f)
+                        run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B23")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    generate_B23(test_f, cover_f)
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    generate_B23(test_f, cover_f, config)

--- a/src/cover_float/testgen/B24.py
+++ b/src/cover_float/testgen/B24.py
@@ -20,6 +20,7 @@
 from typing import Optional, TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
@@ -54,7 +55,7 @@ MAGNITUDES: list[Optional[tuple[int, int, int]]] = [
 ]
 
 
-def generate_B24(test_f: TextIO, cover_f: TextIO) -> None:
+def generate_B24(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for src_fmt in constants.FLOAT_FMTS:
         nf = constants.MANTISSA_BITS[src_fmt]
         bias = constants.EXPONENT_BIAS[src_fmt]
@@ -74,9 +75,9 @@ def generate_B24(test_f: TextIO, cover_f: TextIO) -> None:
                     for sign in (0, 1):
                         f = generate_float(sign, unbiased_exp, fraction, src_fmt)
                         tv = generate_test_vector(constants.OP_CFI, f, 0, 0, src_fmt, dest_fmt, rm)
-                        run_and_store_test_vector(tv, test_f, cover_f)
+                        run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B24")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    generate_B24(test_f, cover_f)
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    generate_B24(test_f, cover_f, config)

--- a/src/cover_float/testgen/B25.py
+++ b/src/cover_float/testgen/B25.py
@@ -18,8 +18,8 @@
 import random
 from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model

--- a/src/cover_float/testgen/B25.py
+++ b/src/cover_float/testgen/B25.py
@@ -18,13 +18,14 @@
 import random
 from typing import TextIO
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
 
 
-def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     seed = reproducible_hash(f"B25 {int_fmt}")
     random.seed(seed)
 
@@ -35,28 +36,28 @@ def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         tv = generate_test_vector(
             constants.OP_CIF, (1 << int_bits) - 1, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
         )
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
         # 0
         tv = generate_test_vector(
             constants.OP_CIF, 0, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
         )
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
         # 1
         tv = generate_test_vector(
             constants.OP_CIF, 1, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
         )
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
         if constants.INT_SIGNED[int_fmt]:
             # - Max Int
             tv = generate_test_vector(
                 constants.OP_CIF, 1 << int_bits | 1, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
             )
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
             # IntMin (maximum negative int)
             tv = generate_test_vector(
                 constants.OP_CIF, 1 << int_bits, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
             )
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
             # -1: Just all ones for twos complement representation
             tv = generate_test_vector(
                 constants.OP_CIF,
@@ -67,7 +68,7 @@ def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 float_fmt,
                 random.choice(constants.ROUNDING_MODES),
             )
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
 
         # Random
         # This generates a random int, possibly with a sign bit (when applicable)
@@ -80,10 +81,10 @@ def generate_B25(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             float_fmt,
             random.choice(constants.ROUNDING_MODES),
         )
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B25")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.INT_FMTS:
-        generate_B25(fmt, test_f, cover_f)
+        generate_B25(fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B26.py
+++ b/src/cover_float/testgen/B26.py
@@ -18,8 +18,8 @@
 import random
 from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model

--- a/src/cover_float/testgen/B26.py
+++ b/src/cover_float/testgen/B26.py
@@ -18,13 +18,14 @@
 import random
 from typing import TextIO
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
 
 
-def generate_B26(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_B26(int_fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     bits = constants.INT_MAX_EXPS[int_fmt]
 
     for float_fmt in constants.FLOAT_FMTS:
@@ -35,7 +36,7 @@ def generate_B26(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             tv = generate_test_vector(
                 constants.OP_CIF, unsigned, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
             )
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
 
             if constants.INT_SIGNED[int_fmt]:
                 signed = -(1 << msb | random.getrandbits(msb)) if msb != -1 else 0
@@ -45,10 +46,10 @@ def generate_B26(int_fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 tv = generate_test_vector(
                     constants.OP_CIF, unsigned, 0, 0, int_fmt, float_fmt, random.choice(constants.ROUNDING_MODES)
                 )
-                run_and_store_test_vector(tv, test_f, cover_f)
+                run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B26")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.INT_FMTS:
-        generate_B26(fmt, test_f, cover_f)
+        generate_B26(fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B27.py
+++ b/src/cover_float/testgen/B27.py
@@ -19,13 +19,14 @@ import itertools
 import random
 from typing import TextIO
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
 
 
-def generate_B27(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_B27(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # We need a QNaN, SNaN, Patterns in Other Bits, and Variations in Sign Bit
 
     for to_fmt in constants.FLOAT_FMTS:
@@ -58,10 +59,10 @@ def generate_B27(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 f |= bits
 
             tv = generate_test_vector(constants.OP_CFF, f, 0, 0, fmt, to_fmt)  # Rounding mode does not matter
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B27")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
-        generate_B27(fmt, test_f, cover_f)
+        generate_B27(fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B27.py
+++ b/src/cover_float/testgen/B27.py
@@ -19,8 +19,8 @@ import itertools
 import random
 from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model

--- a/src/cover_float/testgen/B28.py
+++ b/src/cover_float/testgen/B28.py
@@ -19,12 +19,13 @@ import random
 from typing import TextIO
 
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
 
 
-def generate_B28(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_B28(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     nf = constants.MANTISSA_BITS[fmt]
     p = nf + 1
     bias = constants.EXPONENT_BIAS[fmt]
@@ -33,19 +34,19 @@ def generate_B28(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         # Category 1/10: ±0
         f = generate_float(sign, -bias, 0, fmt)
         tv = generate_test_vector(constants.OP_RFI, f, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
         # Category 2/11: Random in (±0, ±1)
         biased_exp = random.randint(0, bias - 1)
         fraction = random.randint(1, (1 << nf) - 1)
         f = generate_float(sign, biased_exp - bias, fraction, fmt)
         tv = generate_test_vector(constants.OP_RFI, f, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
         # Category 3/12: ±1
         f = generate_float(sign, 0, 0, fmt)
         tv = generate_test_vector(constants.OP_RFI, f, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
     # Category 4/13: Quarter-steps
     # Values: 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75
@@ -65,7 +66,7 @@ def generate_B28(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             frac_shifted = frac_bits << (nf - num_bits)
             f = generate_float(sign, unbiased_exp, frac_shifted, fmt)
             tv = generate_test_vector(constants.OP_RFI, f, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-            run_and_store_test_vector(tv, test_f, cover_f)
+            run_and_store_test_vector(tv, test_f, cover_f, config)
 
     for sign in [0, 1]:
         # Category 5/14: Random in (±1, ±MaxIntFP)
@@ -73,34 +74,34 @@ def generate_B28(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
         fraction = random.getrandbits(nf)
         f = generate_float(sign, biased_exp - bias, fraction, fmt)
         tv = generate_test_vector(constants.OP_RFI, f, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
         # Category 6/15: ±MaxIntFP
         f = generate_float(sign, p, (1 << nf) - 1, fmt)
         tv = generate_test_vector(constants.OP_RFI, f, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
         # Category 7/16: ±∞
         all_ones_exp = (1 << constants.EXPONENT_BITS[fmt]) - 1
         inf = (sign << (constants.EXPONENT_BITS[fmt] + nf)) | (all_ones_exp << nf)
         tv = generate_test_vector(constants.OP_RFI, inf, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-        run_and_store_test_vector(tv, test_f, cover_f)
+        run_and_store_test_vector(tv, test_f, cover_f, config)
 
     # Category 8: QNaN (sign=0, biased_exp=all-ones, fraction MSB=1, rest=0)
     all_ones_exp = (1 << constants.EXPONENT_BITS[fmt]) - 1
     qnan = (all_ones_exp << nf) | (1 << (nf - 1))
     tv = generate_test_vector(constants.OP_RFI, qnan, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-    run_and_store_test_vector(tv, test_f, cover_f)
+    run_and_store_test_vector(tv, test_f, cover_f, config)
 
     # Category 9: SNaN (sign=0, biased_exp=all-ones, fraction MSB=0, LSB=1)
     snan = (all_ones_exp << nf) | 1
     tv = generate_test_vector(constants.OP_RFI, snan, 0, 0, fmt, fmt, constants.ROUND_NEAR_EVEN)
-    run_and_store_test_vector(tv, test_f, cover_f)
+    run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 @register_model("B28")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     seed = reproducible_hash("B28")
     random.seed(seed)
     for fmt in constants.FLOAT_FMTS:
-        generate_B28(fmt, test_f, cover_f)
+        generate_B28(fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B29.py
+++ b/src/cover_float/testgen/B29.py
@@ -19,6 +19,7 @@ import logging
 import random
 from typing import TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 import cover_float.common.log as log
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
@@ -27,8 +28,7 @@ from cover_float.testgen.model import register_model
 
 logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
 
-
-def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     targets = [{"Sign": x & 1, "LSB": (x & 2) >> 1, "Guard": (x & 4) >> 2, "Sticky": (x & 8) >> 3} for x in range(16)]
 
     nf = constants.MANTISSA_BITS[fmt]
@@ -77,6 +77,6 @@ def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
 
 
 @register_model("B29")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
-        generate_tests(fmt, test_f, cover_f)
+        generate_tests(fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B29.py
+++ b/src/cover_float/testgen/B29.py
@@ -15,18 +15,15 @@
 
 # B29 (rwolk@g.hmc.edu)
 
-import logging
 import random
-from typing import TextIO, cast
+from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash, unpack_test_vector
 from cover_float.reference import run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
 
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B1"))
 
 def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     targets = [{"Sign": x & 1, "LSB": (x & 2) >> 1, "Guard": (x & 4) >> 2, "Sticky": (x & 8) >> 3} for x in range(16)]
@@ -71,9 +68,9 @@ def generate_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) ->
             }
 
             if computed_info == target:
-                store_cover_vector(results, test_f, cover_f)
+                store_cover_vector(results, test_f, cover_f, config)
             else:
-                logger.exception(f"Failed to Generate for fmt={fmt} and target={target}")
+                raise ValueError(f"Failed to Generate for fmt={fmt} and target={target}")
 
 
 @register_model("B29")

--- a/src/cover_float/testgen/B3.py
+++ b/src/cover_float/testgen/B3.py
@@ -13,13 +13,11 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-import logging
 import random
-from typing import Optional, TextIO, cast
+from typing import Optional, TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as common
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import (
     extract_rounding_info,
     generate_float,
@@ -30,8 +28,6 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B3"))
 
 SRC1_OPS = [common.OP_SQRT]
 
@@ -211,7 +207,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
 
                 fields = unpack_test_vector(result)
                 if (sigA * sigB) != fields.fma_pre_addition:
-                    logger.exception(
+                    raise ValueError(
                         "FMA PreAddition is being Incorrectly Calculated, Please Investigate"
                         f" {in1:x} * {in2:x} + {in3:x}"
                     )
@@ -219,7 +215,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
                 rounding = extract_rounding_info(result)
 
                 if rounding["Sticky"] != 0:
-                    logger.exception(
+                    raise ValueError(
                         "FMA Sticky Bit Generation Failed! This should not happen, please investigate "
                         f"Inputs: signA={signA}, sigA={sigA:#x}, expA={expA}, signB={signB}, sigB={sigB:#x}, "
                         f"expB={expB}, fmt={fmt}, op={op}"
@@ -234,7 +230,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
                         break
             else:
                 # This catches a for loop that does not break, i.e. we don't hit every goal
-                logger.exception(
+                raise ValueError(
                     f"FMA Generation Failed for fmt={fmt}, mode={mode}, with to_cover={to_cover} goals remaining"
                 )
 
@@ -301,7 +297,7 @@ def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: st
                 if info == target:
                     store_cover_vector(result, test_f, cover_f, config)
                 else:
-                    logger.exception(
+                    raise ValueError(
                         f"AddSub test generation failed: op={op}, target={target}, last_digits={last_digits}, "
                         f"A={A}, B={B}"
                     )
@@ -365,7 +361,7 @@ def write_mul_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
                 if len(goals) == 0:
                     break
         else:
-            logger.exception(
+            raise ValueError(
                 f"Failed to generate mul cover_vectors for fmt={fmt}, mode={mode}. Remaining cases {goals}"
             )
 
@@ -427,9 +423,7 @@ def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) 
         info = extract_rounding_info(result)
 
         if info not in targets:
-            logger.exception(
-                f"sqrt generation sticky bit generation failed, please investigate: mantissa={mantissa:x}, exp={exp}"
-            )
+            msg = f"sqrt generation sticky bit generation failed, please investigate: mantissa={mantissa:x}, exp={exp}"
 
             float_2 = generate_float(0, exp, mantissa & mask, fmt)
             tv_mul = generate_test_vector(common.OP_MUL, float_2, float_2, 0, fmt, fmt)
@@ -437,8 +431,9 @@ def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) 
             gen_square = int(result_mul.split("_")[-6], 16)
 
             if float_ != gen_square:
-                logger.exception(f"sqrt float should have been: {gen_square:x}, was {float_:x}")
-                return
+                msg += f" sqrt float should have been: {gen_square:x}, was {float_:x}"
+
+            raise ValueError(msg)
         else:
             store_cover_vector(result, test_f, cover_f, config)
 
@@ -512,11 +507,10 @@ def write_div_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
             sig_quotient = (sig1_64) // sig2
 
             if sig_quotient * sig2 != sig1_64:
-                logger.exception(
+                raise ValueError(
                     f"Failed to generate exact division result, please investigate: target={target} K={K}, "
                     f"odd_factors={odd_factors}, sig1={sig1:x}, sig2={sig2:x}"
                 )
-                continue
 
             # We want an additional shift to get the lsb into guard
             # So, lsb --> mantissa + 1
@@ -549,7 +543,7 @@ def write_div_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
             """
 
             if info != target:
-                logger.exception(
+                raise ValueError(
                     f"Failed to generate exact division result, please investigate: target={target}, K={K}, "
                     f"odd_factors={odd_factors}, sig1={sig1:x}, sig2={sig2:x}"
                 )
@@ -642,7 +636,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
                 }
 
                 if expected_result != info:
-                    logger.exception(
+                    raise ValueError(
                         f"CFI Generation Unexpected Value, fmt={fmt}, target={target_fmt}, mode={mode},"
                         f"cvt_from={cvt_from:x}"
                     )
@@ -653,7 +647,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
                     if len(goals) == 0:
                         break
             else:
-                logger.exception(
+                raise ValueError(
                     f"CFI Generation Failed: fmt={fmt}, target={target_fmt}, mode={mode}, remaining_goals={goals}"
                 )
 
@@ -693,7 +687,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -
                     if len(goals) == 0:
                         break
             else:
-                logger.exception(
+                raise ValueError(
                     f"CFF Generation Failed: fmt={fmt}, target_fmt={target_fmt}, mode={mode}, remaining_goals={goals}"
                 )
 
@@ -788,6 +782,6 @@ def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
                     if len(cover_goals) == 0:
                         break
                 else:
-                    logger.exception(
+                    raise ValueError(
                         f"Sticky=1 Random Generation Miss: op={op}, fmt={fmt}, goals_remaining={cover_goals}"
                     )

--- a/src/cover_float/testgen/B3.py
+++ b/src/cover_float/testgen/B3.py
@@ -17,6 +17,7 @@ import logging
 import random
 from typing import Optional, TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as common
 import cover_float.common.log as log
 from cover_float.common.util import (
@@ -60,7 +61,7 @@ def get_significand_from_float(float_: int, fmt: str) -> int:
     return float_ & mask | (1 << common.MANTISSA_BITS[fmt])
 
 
-def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def write_fma_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     FMA_OPS = [
         common.OP_FMADD,
         common.OP_FMSUB,
@@ -226,7 +227,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
                 if rounding in to_cover:
                     to_cover.remove(rounding)
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
 
                     # This means we're done
                     if len(to_cover) == 0:
@@ -238,7 +239,7 @@ def write_fma_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 )
 
 
-def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     ops = [
         common.OP_ADD,
         common.OP_SUB,
@@ -298,7 +299,7 @@ def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
                 info = extract_rounding_info(result)
                 if info == target:
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
                 else:
                     logger.exception(
                         f"AddSub test generation failed: op={op}, target={target}, last_digits={last_digits}, "
@@ -306,7 +307,7 @@ def write_add_sub_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     )
 
 
-def write_mul_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def write_mul_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     targets = [
         {
             "Sign": (x & 1),
@@ -359,7 +360,7 @@ def write_mul_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
             if info in goals:
                 goals.remove(info)
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
 
                 if len(goals) == 0:
                     break
@@ -369,7 +370,7 @@ def write_mul_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
             )
 
 
-def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     """
     SQRT is fun. LSB  = 1 and Guard = 1 is impossible. We know this because
     consider squaring a number with guard = 1 and an m bit mantissa
@@ -439,10 +440,10 @@ def write_sqrt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 logger.exception(f"sqrt float should have been: {gen_square:x}, was {float_:x}")
                 return
         else:
-            store_cover_vector(result, test_f, cover_f)
+            store_cover_vector(result, test_f, cover_f, config)
 
 
-def write_div_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def write_div_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     """
     We can generate guard = 1, sticky = 0, unlike square root, but the machinery is going to be
     very specific. When sticky = 0, we have an exact result. This means that the given quotient
@@ -554,13 +555,13 @@ def write_div_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                 )
             else:
                 goals.remove(info)
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
 
                 if len(goals) == 0:
                     break
 
 
-def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def write_cvt_tests(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     cvt_ops_targets = {
         common.OP_CFI: common.INT_FMTS,
         common.OP_CIF: common.INT_FMTS,
@@ -647,7 +648,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
                     )
                 elif info in goals:
                     goals.remove(info)
-                    store_cover_vector(results, test_f, cover_f)
+                    store_cover_vector(results, test_f, cover_f, config)
 
                     if len(goals) == 0:
                         break
@@ -687,7 +688,7 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
                 if info in goals:
                     goals.remove(info)
-                    store_cover_vector(results, test_f, cover_f)
+                    store_cover_vector(results, test_f, cover_f, config)
 
                     if len(goals) == 0:
                         break
@@ -730,28 +731,28 @@ def write_cvt_tests(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
 
                 if info in goals:
                     goals.remove(info)
-                    store_cover_vector(results, test_f, cover_f)
+                    store_cover_vector(results, test_f, cover_f, config)
 
                     if len(goals) == 0:
                         break
             else:
-                logger.exception(
+                raise ValueError(
                     f"CIF Test Gen Failed: fmt={fmt}, from={target_fmt}, mode={mode}, remaining_goals={goals}"
                 )
 
 
 @register_model("B3")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     random.seed(reproducible_hash("B3"))
 
     # These are going to be for sticky = 0
     for fmt in common.FLOAT_FMTS:
-        write_add_sub_tests(test_f, cover_f, fmt)
-        write_mul_tests(test_f, cover_f, fmt)
-        write_div_tests(test_f, cover_f, fmt)
-        write_sqrt_tests(test_f, cover_f, fmt)
-        write_fma_tests(test_f, cover_f, fmt)
-        write_cvt_tests(test_f, cover_f, fmt)
+        write_add_sub_tests(test_f, cover_f, config, fmt)
+        write_mul_tests(test_f, cover_f, config, fmt)
+        write_div_tests(test_f, cover_f, config, fmt)
+        write_sqrt_tests(test_f, cover_f, config, fmt)
+        write_fma_tests(test_f, cover_f, config, fmt)
+        write_cvt_tests(test_f, cover_f, config, fmt)
 
     targets = [
         {
@@ -782,7 +783,7 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
 
                     if rounding_results in cover_goals:
                         cover_goals.remove(rounding_results)
-                        store_cover_vector(cv, test_f, cover_f)
+                        store_cover_vector(cv, test_f, cover_f, config)
 
                     if len(cover_goals) == 0:
                         break

--- a/src/cover_float/testgen/B4.py
+++ b/src/cover_float/testgen/B4.py
@@ -25,6 +25,7 @@ import random
 from collections.abc import Generator
 from typing import TYPE_CHECKING, TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as const
 import cover_float.common.log as log
 from cover_float.common.util import factors_to_bit_width, reproducible_hash
@@ -235,9 +236,10 @@ def _emit(
     fmt: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
 ) -> None:
     tv = f"{op}_{rm}_{a}_{b}_{c}_{fmt}_{ZERO_PAD}_{fmt}_00"
-    run_and_store_test_vector(tv, test_f, cover_f)
+    run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 def _emit_convert(
@@ -248,9 +250,10 @@ def _emit_convert(
     target_fmt: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
 ) -> None:
     tv = f"{op}_{rm}_{a}_{ZERO_PAD}_{ZERO_PAD}_{fmt}_{ZERO_PAD}_{target_fmt}_00"
-    run_and_store_test_vector(tv, test_f, cover_f)
+    run_and_store_test_vector(tv, test_f, cover_f, config)
 
 
 # ---------------------------------------------------------------------------
@@ -258,7 +261,7 @@ def _emit_convert(
 # ---------------------------------------------------------------------------
 
 
-def _group1a_tk(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group1a_tk(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     """
     7 k values x 8 operations x 2 signs x 5 rounding modes = 560 vectors.
 
@@ -313,14 +316,14 @@ def _group1a_tk(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: Te
                 fnmsub_c = neg_k_ulp
 
             for rm in ROUND_MODES:
-                _emit(const.OP_ADD, rm, mn, add_b, ZERO_PAD, fmt, test_f, cover_f)
-                _emit(const.OP_SUB, rm, mn, sub_b, ZERO_PAD, fmt, test_f, cover_f)
-                _emit(const.OP_MUL, rm, tk2, two, ZERO_PAD, fmt, test_f, cover_f)
-                _emit(const.OP_DIV, rm, tk2, half, ZERO_PAD, fmt, test_f, cover_f)
-                _emit(const.OP_FMADD, rm, hmn, two, fmadd_c, fmt, test_f, cover_f)
-                _emit(const.OP_FMSUB, rm, hmn, two, fmsub_c, fmt, test_f, cover_f)
-                _emit(const.OP_FNMADD, rm, hmn_op, two, fnmadd_c, fmt, test_f, cover_f)
-                _emit(const.OP_FNMSUB, rm, hmn_op, two, fnmsub_c, fmt, test_f, cover_f)
+                _emit(const.OP_ADD, rm, mn, add_b, ZERO_PAD, fmt, test_f, cover_f, config)
+                _emit(const.OP_SUB, rm, mn, sub_b, ZERO_PAD, fmt, test_f, cover_f, config)
+                _emit(const.OP_MUL, rm, tk2, two, ZERO_PAD, fmt, test_f, cover_f, config)
+                _emit(const.OP_DIV, rm, tk2, half, ZERO_PAD, fmt, test_f, cover_f, config)
+                _emit(const.OP_FMADD, rm, hmn, two, fmadd_c, fmt, test_f, cover_f, config)
+                _emit(const.OP_FMSUB, rm, hmn, two, fmsub_c, fmt, test_f, cover_f, config)
+                _emit(const.OP_FNMADD, rm, hmn_op, two, fnmadd_c, fmt, test_f, cover_f, config)
+                _emit(const.OP_FNMSUB, rm, hmn_op, two, fnmsub_c, fmt, test_f, cover_f, config)
 
 
 # ---------------------------------------------------------------------------
@@ -328,7 +331,7 @@ def _group1a_tk(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: Te
 # ---------------------------------------------------------------------------
 
 
-def _group1b_arithmetic(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group1b_arithmetic(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     """
     7 LGS configs x 6 operations x 2 signs x 5 rounding modes = 420 vectors.
 
@@ -391,12 +394,12 @@ def _group1b_arithmetic(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cov
                 c_fnmsub = b_lgs_neg
 
             for rm in ROUND_MODES:
-                _emit(const.OP_ADD, rm, a_add, b_add, ZERO_PAD, fmt, test_f, cover_f)
-                _emit(const.OP_SUB, rm, a_sub, b_sub, ZERO_PAD, fmt, test_f, cover_f)
-                _emit(const.OP_FMADD, rm, a_fmadd, one, c_fmadd, fmt, test_f, cover_f)
-                _emit(const.OP_FMSUB, rm, a_fmsub, one, c_fmsub, fmt, test_f, cover_f)
-                _emit(const.OP_FNMADD, rm, a_fnmadd, one, c_fnmadd, fmt, test_f, cover_f)
-                _emit(const.OP_FNMSUB, rm, a_fnmsub, one, c_fnmsub, fmt, test_f, cover_f)
+                _emit(const.OP_ADD, rm, a_add, b_add, ZERO_PAD, fmt, test_f, cover_f, config)
+                _emit(const.OP_SUB, rm, a_sub, b_sub, ZERO_PAD, fmt, test_f, cover_f, config)
+                _emit(const.OP_FMADD, rm, a_fmadd, one, c_fmadd, fmt, test_f, cover_f, config)
+                _emit(const.OP_FMSUB, rm, a_fmsub, one, c_fmsub, fmt, test_f, cover_f, config)
+                _emit(const.OP_FNMADD, rm, a_fnmadd, one, c_fnmadd, fmt, test_f, cover_f, config)
+                _emit(const.OP_FNMSUB, rm, a_fnmsub, one, c_fnmsub, fmt, test_f, cover_f, config)
 
 
 # ---------------------------------------------------------------------------
@@ -442,7 +445,7 @@ def _generate_group1b_mul_factors(
         yield (a, b)
 
 
-def _group1b_mul_div(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group1b_mul_div(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     """
     1 LGS config x 2 operations x 2 signs x 5 rounding modes = 20 vectors.
 
@@ -458,11 +461,11 @@ def _group1b_mul_div(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_
     for sign in (0, 1):
         mn = _maxnorm(sign, E, M)
         for rm in ROUND_MODES:
-            _emit(const.OP_DIV, rm, mn, one, ZERO_PAD, fmt, test_f, cover_f)
+            _emit(const.OP_DIV, rm, mn, one, ZERO_PAD, fmt, test_f, cover_f, config)
 
     for rm in ROUND_MODES:
         for a, b in _generate_group1b_mul_factors(fmt, E, M, bias, rm):
-            _emit(const.OP_MUL, rm, a, b, ZERO_PAD, fmt, test_f, cover_f)
+            _emit(const.OP_MUL, rm, a, b, ZERO_PAD, fmt, test_f, cover_f, config)
 
 
 def generate_exact_mul_group1b(fmt: str, lsb_zero: bool, bits: int, nf: int) -> tuple[int, int]:
@@ -525,7 +528,9 @@ def generate_inexact_mul_group1b(fmt: str, lsb_zero: bool, bits: int, nf: int) -
 # ---------------------------------------------------------------------------
 
 
-def _group2_clear_overflow(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group2_clear_overflow(
+    fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     """
     8 operations x 2 signs x 5 rounding modes = 80 vectors.
 
@@ -555,21 +560,21 @@ def _group2_clear_overflow(fmt: str, E: int, M: int, bias: int, test_f: TextIO, 
         mn_op = _maxnorm(1 - sign, E, M)  # opposite-sign MaxNorm, used only for SUB
         for rm in ROUND_MODES:
             # ADD: ±MaxNorm + ±MaxNorm = ±2*MaxNorm
-            _emit(const.OP_ADD, rm, mn, mn, ZERO_PAD, fmt, test_f, cover_f)
+            _emit(const.OP_ADD, rm, mn, mn, ZERO_PAD, fmt, test_f, cover_f, config)
             # SUB: ±MaxNorm - (∓MaxNorm) = ±2*MaxNorm
-            _emit(const.OP_SUB, rm, mn, mn_op, ZERO_PAD, fmt, test_f, cover_f)
+            _emit(const.OP_SUB, rm, mn, mn_op, ZERO_PAD, fmt, test_f, cover_f, config)
             # MUL: ±MaxNorm x 2.0 = ±2*MaxNorm
-            _emit(const.OP_MUL, rm, mn, two, ZERO_PAD, fmt, test_f, cover_f)
+            _emit(const.OP_MUL, rm, mn, two, ZERO_PAD, fmt, test_f, cover_f, config)
             # DIV: ±MaxNorm / 0.5 = ±2*MaxNorm
-            _emit(const.OP_DIV, rm, mn, _half_fp(E, M, bias), ZERO_PAD, fmt, test_f, cover_f)
+            _emit(const.OP_DIV, rm, mn, _half_fp(E, M, bias), ZERO_PAD, fmt, test_f, cover_f, config)
             # FMADD: (±Mn/2 x 2) + ±Mn = ±2*Mn
-            _emit(const.OP_FMADD, rm, hmn, two, mn, fmt, test_f, cover_f)
+            _emit(const.OP_FMADD, rm, hmn, two, mn, fmt, test_f, cover_f, config)
             # FMSUB: (±Mn/2 x 2) - (∓Mn) = ±2*Mn
-            _emit(const.OP_FMSUB, rm, hmn, two, mn_op, fmt, test_f, cover_f)
+            _emit(const.OP_FMSUB, rm, hmn, two, mn_op, fmt, test_f, cover_f, config)
             # FNMADD: -(∓Mn/2 x 2) - (∓Mn) = ±Mn + ±Mn = ±2*Mn
-            _emit(const.OP_FNMADD, rm, hmn_op, two, mn_op, fmt, test_f, cover_f)
+            _emit(const.OP_FNMADD, rm, hmn_op, two, mn_op, fmt, test_f, cover_f, config)
             # FNMSUB: -(∓Mn/2 x 2) + (±Mn) = ±Mn + ±Mn = ±2*Mn
-            _emit(const.OP_FNMSUB, rm, hmn_op, two, mn, fmt, test_f, cover_f)
+            _emit(const.OP_FNMSUB, rm, hmn_op, two, mn, fmt, test_f, cover_f, config)
 
 
 def _generate_group2_mul_factors(
@@ -589,7 +594,7 @@ def _generate_group2_mul_factors(
 # ---------------------------------------------------------------------------
 
 
-def _group3_exp_sweep(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group3_exp_sweep(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     """
     7 exponents x 8 operations x 2 signs x 5 rounding modes = 560 vectors.
 
@@ -631,16 +636,16 @@ def _group3_exp_sweep(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover
                     a = a_neg if sign == 1 else a_pos  # dominant operand
                     an = a_pos if sign == 1 else a_neg  # negated dominant (for FN* ops)
 
-                    _emit(const.OP_ADD, rm, a, ZERO_PAD, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_SUB, rm, a, ZERO_PAD, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_MUL, rm, a, one, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_DIV, rm, a, one, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_FMADD, rm, a, one, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_FMSUB, rm, a, one, ZERO_PAD, fmt, test_f, cover_f)
+                    _emit(const.OP_ADD, rm, a, ZERO_PAD, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_SUB, rm, a, ZERO_PAD, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_MUL, rm, a, one, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_DIV, rm, a, one, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_FMADD, rm, a, one, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_FMSUB, rm, a, one, ZERO_PAD, fmt, test_f, cover_f, config)
                     # FNMADD: -(an x 1) - 0 = -an.  For sign=0: an=a_neg, so -an = +a_pos ✓
                     #                                 For sign=1: an=a_pos, so -an = -a_pos ✓
-                    _emit(const.OP_FNMADD, rm, an, one, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_FNMSUB, rm, an, one, ZERO_PAD, fmt, test_f, cover_f)
+                    _emit(const.OP_FNMADD, rm, an, one, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_FNMSUB, rm, an, one, ZERO_PAD, fmt, test_f, cover_f, config)
 
                 else:  # d > 0
                     scale = _pow2(d, E, M, bias)  # +2^d
@@ -658,19 +663,19 @@ def _group3_exp_sweep(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover
                     # ADD: MaxNorm + MaxNorm (reaches d=1 intermediate; structural
                     #      impossibility for d>1, covergroup excludes those bins)
                     mn_for_add = mn_neg if sign == 1 else mn
-                    _emit(const.OP_ADD, rm, mn_for_add, mn_for_add, ZERO_PAD, fmt, test_f, cover_f)
+                    _emit(const.OP_ADD, rm, mn_for_add, mn_for_add, ZERO_PAD, fmt, test_f, cover_f, config)
                     # SUB: MaxNorm - (-MaxNorm) = 2*MaxNorm
                     mn_for_sub_b = mn if sign == 1 else mn_neg
-                    _emit(const.OP_SUB, rm, mn_for_add, mn_for_sub_b, ZERO_PAD, fmt, test_f, cover_f)
+                    _emit(const.OP_SUB, rm, mn_for_add, mn_for_sub_b, ZERO_PAD, fmt, test_f, cover_f, config)
 
-                    _emit(const.OP_MUL, rm, a, scale, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_DIV, rm, a, scale_inv, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_FMADD, rm, a, scale, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_FMSUB, rm, a, scale, ZERO_PAD, fmt, test_f, cover_f)
+                    _emit(const.OP_MUL, rm, a, scale, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_DIV, rm, a, scale_inv, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_FMADD, rm, a, scale, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_FMSUB, rm, a, scale, ZERO_PAD, fmt, test_f, cover_f, config)
                     # FNMADD: -(an x 2^d) - 0.  For sign=0: an=mn_neg, -(-Mnx2^d)=+Mnx2^d ✓
                     #                             For sign=1: an=mn,    -(+Mnx2^d)=-Mnx2^d ✓
-                    _emit(const.OP_FNMADD, rm, an, scale, ZERO_PAD, fmt, test_f, cover_f)
-                    _emit(const.OP_FNMSUB, rm, an, scale, ZERO_PAD, fmt, test_f, cover_f)
+                    _emit(const.OP_FNMADD, rm, an, scale, ZERO_PAD, fmt, test_f, cover_f, config)
+                    _emit(const.OP_FNMSUB, rm, an, scale, ZERO_PAD, fmt, test_f, cover_f, config)
 
 
 def _generate_group3_mul_factors(
@@ -713,7 +718,7 @@ def get_mul_inputs(fmt: str, rm: str) -> Generator[tuple[str, str], None, None]:
     yield from _generate_group3_mul_factors(fmt, E, M, bias, rm)
 
 
-def _group1_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group1_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # Generate CFF Tests between MaxNorm - 3ulp and MaxNorm + 3ulp
 
     for target in const.FLOAT_FMTS:
@@ -733,10 +738,10 @@ def _group1_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_
 
             a = _fp_hex(sign, exp + bias, mantissa, E, M)
 
-            _emit_convert(const.OP_CFF, rm, a, fmt, target, test_f, cover_f)
+            _emit_convert(const.OP_CFF, rm, a, fmt, target, test_f, cover_f, config)
 
 
-def _group2_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group2_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # A Random Number Larger than MaxNorm + 3 ulp
 
     for target in const.FLOAT_FMTS:
@@ -755,10 +760,10 @@ def _group2_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_
 
             a = _fp_hex(sign, exp + bias, mantissa, E, M)
 
-            _emit_convert(const.OP_CFF, rm, a, fmt, target, test_f, cover_f)
+            _emit_convert(const.OP_CFF, rm, a, fmt, target, test_f, cover_f, config)
 
 
-def _group3_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO) -> None:
+def _group3_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # Numbers with exponent in the range MaxNorm.Exp +- 3
 
     for target in const.FLOAT_FMTS:
@@ -776,7 +781,7 @@ def _group3_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_
 
             a = _fp_hex(sign, exp + bias, mantissa, E, M)
 
-            _emit_convert(const.OP_CFF, rm, a, fmt, target, test_f, cover_f)
+            _emit_convert(const.OP_CFF, rm, a, fmt, target, test_f, cover_f, config)
 
 
 # ---------------------------------------------------------------------------
@@ -784,25 +789,25 @@ def _group3_converts(fmt: str, E: int, M: int, bias: int, test_f: TextIO, cover_
 # ---------------------------------------------------------------------------
 
 
-def generate_b4_tests_arithmetic(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def generate_b4_tests_arithmetic(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     E, M, bias = _fmt_params(fmt)
-    _group1a_tk(fmt, E, M, bias, test_f, cover_f)
-    _group1b_arithmetic(fmt, E, M, bias, test_f, cover_f)
-    _group1b_mul_div(fmt, E, M, bias, test_f, cover_f)
-    _group2_clear_overflow(fmt, E, M, bias, test_f, cover_f)
-    _group3_exp_sweep(fmt, E, M, bias, test_f, cover_f)
+    _group1a_tk(fmt, E, M, bias, test_f, cover_f, config)
+    _group1b_arithmetic(fmt, E, M, bias, test_f, cover_f, config)
+    _group1b_mul_div(fmt, E, M, bias, test_f, cover_f, config)
+    _group2_clear_overflow(fmt, E, M, bias, test_f, cover_f, config)
+    _group3_exp_sweep(fmt, E, M, bias, test_f, cover_f, config)
 
 
-def generate_b4_tests_converts(test_f: TextIO, cover_f: TextIO, fmt: str) -> None:
+def generate_b4_tests_converts(test_f: TextIO, cover_f: TextIO, config: Config, fmt: str) -> None:
     E, M, bias = _fmt_params(fmt)
-    _group1_converts(fmt, E, M, bias, test_f, cover_f)
-    _group2_converts(fmt, E, M, bias, test_f, cover_f)
-    _group3_converts(fmt, E, M, bias, test_f, cover_f)
+    _group1_converts(fmt, E, M, bias, test_f, cover_f, config)
+    _group2_converts(fmt, E, M, bias, test_f, cover_f, config)
+    _group3_converts(fmt, E, M, bias, test_f, cover_f, config)
 
 
 @register_model("B4")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in const.FLOAT_FMTS:
         random.seed(reproducible_hash(f"B4 {fmt}"))
-        generate_b4_tests_arithmetic(test_f, cover_f, fmt)
-        generate_b4_tests_converts(test_f, cover_f, fmt)
+        generate_b4_tests_arithmetic(test_f, cover_f, config, fmt)
+        generate_b4_tests_converts(test_f, cover_f, config, fmt)

--- a/src/cover_float/testgen/B4.py
+++ b/src/cover_float/testgen/B4.py
@@ -20,14 +20,12 @@
 #   Total: 1640 / format * 5 formats = 8200 vectors.
 
 import itertools
-import logging
 import random
 from collections.abc import Generator
-from typing import TYPE_CHECKING, TextIO, cast
+from typing import TYPE_CHECKING, TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as const
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import factors_to_bit_width, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model
@@ -37,8 +35,6 @@ if TYPE_CHECKING:
     def factorint(n: int) -> dict[int, int]: ...
 else:
     from sympy import factorint
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B4"))
 
 ZERO_PAD = "0" * 32
 

--- a/src/cover_float/testgen/B5.py
+++ b/src/cover_float/testgen/B5.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from random import seed
 from typing import TextIO
 
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     EXPONENT_BIAS,
     EXPONENT_BITS,
@@ -79,7 +80,15 @@ def generate_FP(
 
 
 def convert_grs(
-    hp: str, lp: str, g_exp: int, grs: str, sign: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO
+    hp: str,
+    lp: str,
+    g_exp: int,
+    grs: str,
+    sign: str,
+    rounding_mode: str,
+    test_f: TextIO,
+    cover_f: TextIO,
+    config: Config,
 ) -> None:
     hp_m_bits = MANTISSA_BITS[hp]
     hp_e_bits = EXPONENT_BITS[hp]
@@ -120,17 +129,17 @@ def convert_grs(
 
     input_fp = generate_FP(hp_e_bits, sign, input_exp, input_mant_bin, hp_e_bias)
     run_and_store_test_vector(
-        f"{OP_CFF}_{rounding_mode}_{input_fp}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00", test_f, cover_f
+        f"{OP_CFF}_{rounding_mode}_{input_fp}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00", test_f, cover_f, config
     )
 
 
-def tests_conversion_1_2(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_conversion_1_2(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     hashval = reproducible_hash(OP_CFF + lp + "b5")
     seed(hashval)
     lp_min_exp = UNBIASED_EXP[lp][0]
 
-    convert_grs(hp, lp, lp_min_exp + 1, "001", "0", rounding_mode, test_f, cover_f)
-    convert_grs(hp, lp, lp_min_exp + 1, "001", "1", rounding_mode, test_f, cover_f)
+    convert_grs(hp, lp, lp_min_exp + 1, "001", "0", rounding_mode, test_f, cover_f, config)
+    convert_grs(hp, lp, lp_min_exp + 1, "001", "1", rounding_mode, test_f, cover_f, config)
 
 
 def genPNTestVectors(
@@ -144,6 +153,7 @@ def genPNTestVectors(
     hp_e_bias: int,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
 ) -> None:
 
     hashval = reproducible_hash(OP_CFF + lp + "b5")
@@ -152,14 +162,20 @@ def genPNTestVectors(
     input_value_2 = generate_FP(hp_e_bits, "1", hp_exp, complete_binary_2, hp_e_bias)
 
     run_and_store_test_vector(
-        f"{OP_CFF}_{rounding_mode}_{input_value_1}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00", test_f, cover_f
+        f"{OP_CFF}_{rounding_mode}_{input_value_1}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00",
+        test_f,
+        cover_f,
+        config,
     )  # Test 1
     run_and_store_test_vector(
-        f"{OP_CFF}_{rounding_mode}_{input_value_2}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00", test_f, cover_f
+        f"{OP_CFF}_{rounding_mode}_{input_value_2}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00",
+        test_f,
+        cover_f,
+        config,
     )  # Test 2
 
 
-def tests_conversion_3_4(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_conversion_3_4(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
 
     hashval = reproducible_hash(OP_CFF + lp + "b5")
     seed(hashval)
@@ -170,11 +186,11 @@ def tests_conversion_3_4(lp: str, hp: str, rounding_mode: str, test_f: TextIO, c
 
     grs = ["001", "010", "011", "100", "101", "110", "111"]
     for bits in grs:
-        convert_grs(hp, lp, lp_min_exp + 1, bits, "0", rounding_mode, test_f, cover_f)
-        convert_grs(hp, lp, lp_min_exp + 1, bits, "1", rounding_mode, test_f, cover_f)
+        convert_grs(hp, lp, lp_min_exp + 1, bits, "0", rounding_mode, test_f, cover_f, config)
+        convert_grs(hp, lp, lp_min_exp + 1, bits, "1", rounding_mode, test_f, cover_f, config)
 
 
-def tests_conversion_5_6(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_conversion_5_6(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
 
     hashval = reproducible_hash(OP_CFF + lp + "b5")
     seed(hashval)
@@ -200,7 +216,7 @@ def tests_conversion_5_6(lp: str, hp: str, rounding_mode: str, test_f: TextIO, c
             hp_m = "1" * (lp_m_bits) + "0" + f"{random.randint(1, max_rem >> 1):0{rem_bits - 1}b}"
         hp_exp = lp_sn_exp
 
-        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f)
+        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f, config)
 
         # MinNorm - 2 i_ulp:
         if hp_sn_exp != lp_sn_exp:  # If we need to generate a subnorm, then the criteria for the mantissa is different
@@ -209,7 +225,7 @@ def tests_conversion_5_6(lp: str, hp: str, rounding_mode: str, test_f: TextIO, c
             hp_m = "1" * (lp_m_bits) + "1" + "0" * (rem_bits - 1)
         hp_exp = lp_sn_exp
 
-        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f)
+        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f, config)
 
         # MinNorm - 1 i_ulp:
         if hp_sn_exp != lp_sn_exp:  # If we need to generate a subnorm, then the criteria for the mantissa is different
@@ -220,45 +236,45 @@ def tests_conversion_5_6(lp: str, hp: str, rounding_mode: str, test_f: TextIO, c
             hp_m_2 = "1" * (lp_m_bits) + "1" + f"{random.randint(1, max_rem >> 1):0{rem_bits - 1}b}"
         hp_exp = lp_sn_exp
 
-        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m_1, hp_m_2, hp_e_bias, test_f, cover_f)
+        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m_1, hp_m_2, hp_e_bias, test_f, cover_f, config)
 
         # MinNorm:
         hp_m_1 = "0" * (hp_m_bits)
         hp_m_2 = "0" * (hp_m_bits)
         hp_exp = lp_n_exp
 
-        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m_1, hp_m_2, hp_e_bias, test_f, cover_f)
+        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m_1, hp_m_2, hp_e_bias, test_f, cover_f, config)
 
         # MinNorm + 1 i_ulp:
         hp_m = "0" * lp_m_bits + "0" + f"{random.randint(1, max_rem >> 1):0{rem_bits - 1}b}"
         hp_exp = lp_n_exp
 
-        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f)
+        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f, config)
 
         # MinNorm + 2 i_ulp:
         hp_m = "0" * lp_m_bits + "1" + "0" * (rem_bits - 1)
         hp_exp = lp_n_exp
 
-        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f)
+        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f, config)
 
         # MinNorm + 3 i_ulp:
         hp_m = ("0" * lp_m_bits) + "1" + f"{random.randint(1, (1 << (rem_bits - 1)) - 1):0{(rem_bits - 1)}b}"
         hp_exp = lp_n_exp
 
-        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f)
+        genPNTestVectors(lp, hp, rounding_mode, hp_e_bits, hp_exp, hp_m, hp_m, hp_e_bias, test_f, cover_f, config)
 
 
-def tests_conversion_7_8(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_conversion_7_8(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     hashval = reproducible_hash(OP_CFF + lp + "b5")
     seed(hashval)
 
     lp_sn_exp = UNBIASED_EXP[lp][0] - MANTISSA_BITS[lp] - 3
 
-    convert_grs(hp, lp, lp_sn_exp, "001", "0", rounding_mode, test_f, cover_f)
-    convert_grs(hp, lp, lp_sn_exp, "001", "1", rounding_mode, test_f, cover_f)
+    convert_grs(hp, lp, lp_sn_exp, "001", "0", rounding_mode, test_f, cover_f, config)
+    convert_grs(hp, lp, lp_sn_exp, "001", "1", rounding_mode, test_f, cover_f, config)
 
 
-def tests_conversion_9(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_conversion_9(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     hashval = reproducible_hash(OP_CFF + lp + "b5")
     seed(hashval)
     hp_m_bits = MANTISSA_BITS[hp]
@@ -275,22 +291,25 @@ def tests_conversion_9(lp: str, hp: str, rounding_mode: str, test_f: TextIO, cov
         hp_exp = lp_sn_exp + i
         input_value_1 = generate_FP(hp_e_bits, f"{random.randint(0, 1)}", hp_exp, complete_binary, hp_e_bias)
         run_and_store_test_vector(
-            f"{OP_CFF}_{rounding_mode}_{input_value_1}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00", test_f, cover_f
+            f"{OP_CFF}_{rounding_mode}_{input_value_1}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00",
+            test_f,
+            cover_f,
+            config,
         )  # Test 1
 
 
-def convertTests(test_f: TextIO, cover_f: TextIO) -> None:
+def convertTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # All conversion tests:
     for i_hp in range(len(B5_FMTS)):
         hp = B5_FMTS[i_hp]
         for i_lp in range(i_hp + 1, len(B5_FMTS)):
             lp = B5_FMTS[i_lp]
             for rounding_mode in ROUNDING_MODES:
-                tests_conversion_1_2(lp, hp, rounding_mode, test_f, cover_f)
-                tests_conversion_3_4(lp, hp, rounding_mode, test_f, cover_f)
-                tests_conversion_5_6(lp, hp, rounding_mode, test_f, cover_f)
-                tests_conversion_7_8(lp, hp, rounding_mode, test_f, cover_f)
-                tests_conversion_9(lp, hp, rounding_mode, test_f, cover_f)
+                tests_conversion_1_2(lp, hp, rounding_mode, test_f, cover_f, config)
+                tests_conversion_3_4(lp, hp, rounding_mode, test_f, cover_f, config)
+                tests_conversion_5_6(lp, hp, rounding_mode, test_f, cover_f, config)
+                tests_conversion_7_8(lp, hp, rounding_mode, test_f, cover_f, config)
+                tests_conversion_9(lp, hp, rounding_mode, test_f, cover_f, config)
 
 
 def genSpecExp_mul(precision: str, target: int, hashString: str) -> tuple[int, int]:
@@ -739,7 +758,7 @@ def getMultiplyTests(precision: str, rounding_mode: str) -> Iterator[tuple[str, 
     yield from tests_multiply_9(precision, rounding_mode)
 
 
-def multiplyTests(test_f: TextIO, cover_f: TextIO) -> None:
+def multiplyTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for precision in FLOAT_FMTS:
         for rounding_mode in ROUNDING_MODES:
             for a, b in getMultiplyTests(precision, rounding_mode):
@@ -747,6 +766,7 @@ def multiplyTests(test_f: TextIO, cover_f: TextIO) -> None:
                     f"{OP_MUL}_{rounding_mode}_{a}_{b}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
                     test_f,
                     cover_f,
+                    config,
                 )
 
 
@@ -761,6 +781,7 @@ def fma_gen(
     addend_pattern: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
     hashEnding: str,
 ) -> None:
     m_bits = MANTISSA_BITS[precision]
@@ -824,25 +845,29 @@ def fma_gen(
         c_bin_mant = f"{c_mant:0{m_bits}b}"
         c = generate_FP(e_bits, str(c_sign), c_exp, c_bin_mant, e_bias)
         run_and_store_test_vector(
-            f"{operation}_{rounding_mode}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+            f"{operation}_{rounding_mode}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f, config
         )
 
 
-def tests_fma_1_2(operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_fma_1_2(
+    operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     m_bits = MANTISSA_BITS[precision]
     min_exp = UNBIASED_EXP[precision][0]
 
     minSNPos = min_exp - m_bits
 
     fma_gen(
-        operation, precision, rounding_mode, 0, "001", minSNPos, 1, "rand_sn", test_f, cover_f, "pos_1"
+        operation, precision, rounding_mode, 0, "001", minSNPos, 1, "rand_sn", test_f, cover_f, config, "pos_1"
     )  # adds decreased magnitude, can't be normal
     fma_gen(
-        operation, precision, rounding_mode, 1, "001", minSNPos, 0, "rand_sn", test_f, cover_f, "neg_2"
+        operation, precision, rounding_mode, 1, "001", minSNPos, 0, "rand_sn", test_f, cover_f, config, "neg_2"
     )  # add decreases magnitude, can't be normal
 
 
-def tests_fma_3_4(operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_fma_3_4(
+    operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     m_bits = MANTISSA_BITS[precision]
     min_exp = UNBIASED_EXP[precision][0]
 
@@ -850,38 +875,64 @@ def tests_fma_3_4(operation: str, precision: str, rounding_mode: str, test_f: Te
 
     # MinSN - 3 ulp; G = 1, R = 0, S = 1
     fma_gen(
-        operation, precision, rounding_mode, 0, "101", minSNPos, 1, "min_sn", test_f, cover_f, "pos_-3_ulp_3"
+        operation, precision, rounding_mode, 0, "101", minSNPos, 1, "min_sn", test_f, cover_f, config, "pos_-3_ulp_3"
     )  # Get rid of G Bit and some more from sticky, result is negative
-    fma_gen(operation, precision, rounding_mode, 1, "101", minSNPos, 0, "min_sn", test_f, cover_f, "neg_-3_ulp_4")
+    fma_gen(
+        operation, precision, rounding_mode, 1, "101", minSNPos, 0, "min_sn", test_f, cover_f, config, "neg_-3_ulp_4"
+    )
 
     # MinSN - 2 ulp; G = 1, R = 1, S = 0
     fma_gen(
-        operation, precision, rounding_mode, 1, "010", minSNPos, 0, "min_sn", test_f, cover_f, "pos_-2_ulp_3"
+        operation, precision, rounding_mode, 1, "010", minSNPos, 0, "min_sn", test_f, cover_f, config, "pos_-2_ulp_3"
     )  # Subtract minSN from 1 bit 2*minSN
-    fma_gen(operation, precision, rounding_mode, 0, "010", minSNPos, 1, "min_sn", test_f, cover_f, "neg_-2_ulp_4")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "010", minSNPos, 1, "min_sn", test_f, cover_f, config, "neg_-2_ulp_4"
+    )
 
     # MinSN - 1 ulp; G = 0, R = 1, S = 1
-    fma_gen(operation, precision, rounding_mode, 0, "111", minSNPos, 1, "min_sn", test_f, cover_f, "pos_-1_ulp_3")
-    fma_gen(operation, precision, rounding_mode, 1, "111", minSNPos, 0, "min_sn", test_f, cover_f, "neg_-1_ulp_4")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "111", minSNPos, 1, "min_sn", test_f, cover_f, config, "pos_-1_ulp_3"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "111", minSNPos, 0, "min_sn", test_f, cover_f, config, "neg_-1_ulp_4"
+    )
 
     # #MinSN; G = 1, R = 0, S = 0
-    fma_gen(operation, precision, rounding_mode, 0, "100", minSNPos, 1, "2*min_sn", test_f, cover_f, "pos_minSN_3")
-    fma_gen(operation, precision, rounding_mode, 1, "100", minSNPos, 0, "2*min_sn", test_f, cover_f, "neg_minSN_4")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "100", minSNPos, 1, "2*min_sn", test_f, cover_f, config, "pos_minSN_3"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "100", minSNPos, 0, "2*min_sn", test_f, cover_f, config, "neg_minSN_4"
+    )
 
     # MinSN + 1 ulp; G = 1, R = 0, S = 1
-    fma_gen(operation, precision, rounding_mode, 0, "001", minSNPos, 0, "min_sn", test_f, cover_f, "pos_+1_ulp_3")
-    fma_gen(operation, precision, rounding_mode, 1, "001", minSNPos, 1, "min_sn", test_f, cover_f, "neg_+1_ulp_4")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "001", minSNPos, 0, "min_sn", test_f, cover_f, config, "pos_+1_ulp_3"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "001", minSNPos, 1, "min_sn", test_f, cover_f, config, "neg_+1_ulp_4"
+    )
 
     # MinSN + 2 ulp; G = 1, R = 1, S = 0
-    fma_gen(operation, precision, rounding_mode, 0, "010", minSNPos, 0, "min_sn", test_f, cover_f, "pos_+2_ulp_3")
-    fma_gen(operation, precision, rounding_mode, 1, "010", minSNPos, 1, "min_sn", test_f, cover_f, "neg_+2_ulp_4")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "010", minSNPos, 0, "min_sn", test_f, cover_f, config, "pos_+2_ulp_3"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "010", minSNPos, 1, "min_sn", test_f, cover_f, config, "neg_+2_ulp_4"
+    )
 
     # MinSN + 3 ulp; G = 1, R = 1, S = 1
-    fma_gen(operation, precision, rounding_mode, 0, "011", minSNPos, 0, "min_sn", test_f, cover_f, "pos_+3_ulp_3")
-    fma_gen(operation, precision, rounding_mode, 1, "011", minSNPos, 1, "min_sn", test_f, cover_f, "neg_+3_ulp_4")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "011", minSNPos, 0, "min_sn", test_f, cover_f, config, "pos_+3_ulp_3"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "011", minSNPos, 1, "min_sn", test_f, cover_f, config, "neg_+3_ulp_4"
+    )
 
 
-def tests_fma_5_6(operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_fma_5_6(
+    operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     m_bits = MANTISSA_BITS[precision]
     min_exp = UNBIASED_EXP[precision][0]
 
@@ -889,52 +940,102 @@ def tests_fma_5_6(operation: str, precision: str, rounding_mode: str, test_f: Te
 
     # MinN - 3 ulp; G = 1, R = 0, S = 1
     fma_gen(
-        operation, precision, rounding_mode, 0, "101", minSNPos, 0, "1*m-1_0", test_f, cover_f, "pos_-3_ulp_5"
+        operation, precision, rounding_mode, 0, "101", minSNPos, 0, "1*m-1_0", test_f, cover_f, config, "pos_-3_ulp_5"
     )  # Get rid of G Bit and some more from sticky, result is negative
-    fma_gen(operation, precision, rounding_mode, 1, "101", minSNPos, 1, "1*m-1_0", test_f, cover_f, "neg_-3_ulp_6")
+    fma_gen(
+        operation, precision, rounding_mode, 1, "101", minSNPos, 1, "1*m-1_0", test_f, cover_f, config, "neg_-3_ulp_6"
+    )
 
     # MinN - 2 ulp; G = 1, R = 1, S = 0
     fma_gen(
-        operation, precision, rounding_mode, 0, "110", minSNPos, 0, "1*m-1_0", test_f, cover_f, "pos_-2_ulp_5"
+        operation, precision, rounding_mode, 0, "110", minSNPos, 0, "1*m-1_0", test_f, cover_f, config, "pos_-2_ulp_5"
     )  # Get rid of G Bit and some more from sticky, result is negative
-    fma_gen(operation, precision, rounding_mode, 1, "110", minSNPos, 1, "1*m-1_0", test_f, cover_f, "neg_-2_ulp_6")
+    fma_gen(
+        operation, precision, rounding_mode, 1, "110", minSNPos, 1, "1*m-1_0", test_f, cover_f, config, "neg_-2_ulp_6"
+    )
 
     # MinN - 1 ulp; G = 1, R = 1, S = 1
     fma_gen(
-        operation, precision, rounding_mode, 0, "111", minSNPos, 0, "1*m-1_0", test_f, cover_f, "pos_-2_ulp_5"
+        operation, precision, rounding_mode, 0, "111", minSNPos, 0, "1*m-1_0", test_f, cover_f, config, "pos_-2_ulp_5"
     )  # Get rid of G Bit and some more from sticky, result is negative
-    fma_gen(operation, precision, rounding_mode, 1, "111", minSNPos, 1, "1*m-1_0", test_f, cover_f, "neg_-2_ulp_6")
+    fma_gen(
+        operation, precision, rounding_mode, 1, "111", minSNPos, 1, "1*m-1_0", test_f, cover_f, config, "neg_-2_ulp_6"
+    )
 
     # MinN
-    fma_gen(operation, precision, rounding_mode, 1, "100", minSNPos, 0, "1_0*m-1_1", test_f, cover_f, "pos_norm_5")
-    fma_gen(operation, precision, rounding_mode, 0, "100", minSNPos, 1, "1_0*m-1_1", test_f, cover_f, "neg_norm_6")
+    fma_gen(
+        operation, precision, rounding_mode, 1, "100", minSNPos, 0, "1_0*m-1_1", test_f, cover_f, config, "pos_norm_5"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 0, "100", minSNPos, 1, "1_0*m-1_1", test_f, cover_f, config, "neg_norm_6"
+    )
 
     # MinN + 1 ulp
-    fma_gen(operation, precision, rounding_mode, 0, "001", minSNPos, 0, "min_n", test_f, cover_f, "pos_+1_ulp_5")
-    fma_gen(operation, precision, rounding_mode, 1, "001", minSNPos, 1, "min_n", test_f, cover_f, "neg_+1_ulp_6")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "001", minSNPos, 0, "min_n", test_f, cover_f, config, "pos_+1_ulp_5"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "001", minSNPos, 1, "min_n", test_f, cover_f, config, "neg_+1_ulp_6"
+    )
 
     # MinN + 2 ulp
-    fma_gen(operation, precision, rounding_mode, 0, "010", minSNPos, 0, "min_n", test_f, cover_f, "pos_+2_ulp_5")
-    fma_gen(operation, precision, rounding_mode, 1, "010", minSNPos, 1, "min_n", test_f, cover_f, "neg_+2_ulp_6")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "010", minSNPos, 0, "min_n", test_f, cover_f, config, "pos_+2_ulp_5"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "010", minSNPos, 1, "min_n", test_f, cover_f, config, "neg_+2_ulp_6"
+    )
 
     # MinN + 3 ulp
-    fma_gen(operation, precision, rounding_mode, 0, "011", minSNPos, 0, "min_n", test_f, cover_f, "pos_+3_ulp_5")
-    fma_gen(operation, precision, rounding_mode, 1, "011", minSNPos, 1, "min_n", test_f, cover_f, "neg_+3_ulp_6")
+    fma_gen(
+        operation, precision, rounding_mode, 0, "011", minSNPos, 0, "min_n", test_f, cover_f, config, "pos_+3_ulp_5"
+    )
+    fma_gen(
+        operation, precision, rounding_mode, 1, "011", minSNPos, 1, "min_n", test_f, cover_f, config, "neg_+3_ulp_6"
+    )
 
 
-def tests_fma_7_8(operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_fma_7_8(
+    operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     m_bits = MANTISSA_BITS[precision]
     min_exp = UNBIASED_EXP[precision][0]
 
     minSNPos = min_exp - m_bits
 
     fma_gen(
-        operation, precision, rounding_mode, 0, "011", minSNPos + 1, 1, "min_sn", test_f, cover_f, "pos_-3_ulp_3"
+        operation,
+        precision,
+        rounding_mode,
+        0,
+        "011",
+        minSNPos + 1,
+        1,
+        "min_sn",
+        test_f,
+        cover_f,
+        config,
+        "pos_-3_ulp_3",
     )  # Get rid of G Bit and some more from sticky, result is negative
-    fma_gen(operation, precision, rounding_mode, 1, "011", minSNPos + 1, 0, "min_sn", test_f, cover_f, "neg_-3_ulp_4")
+    fma_gen(
+        operation,
+        precision,
+        rounding_mode,
+        1,
+        "011",
+        minSNPos + 1,
+        0,
+        "min_sn",
+        test_f,
+        cover_f,
+        config,
+        "neg_-3_ulp_4",
+    )
 
 
-def tests_fma_9(operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_fma_9(
+    operation: str, precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config
+) -> None:
     m_bits = MANTISSA_BITS[precision]
     min_exp = UNBIASED_EXP[precision][0]
 
@@ -951,6 +1052,7 @@ def tests_fma_9(operation: str, precision: str, rounding_mode: str, test_f: Text
             f"randexp_{abs(exp)}",
             test_f,
             cover_f,
+            config,
             f"pos_-3_ulp_{exp}",
         )
         fma_gen(
@@ -964,24 +1066,26 @@ def tests_fma_9(operation: str, precision: str, rounding_mode: str, test_f: Text
             f"randexp_{abs(exp)}",
             test_f,
             cover_f,
+            config,
             f"pos_-3_ulp_{exp}",
         )
 
 
-def fmaTests(test_f: TextIO, cover_f: TextIO) -> None:
+def fmaTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for operation in FMA_OPS:
         for precision in FLOAT_FMTS:
             for rounding_mode in ROUNDING_MODES:
-                tests_fma_1_2(operation, precision, rounding_mode, test_f, cover_f)
-                tests_fma_3_4(operation, precision, rounding_mode, test_f, cover_f)
-                tests_fma_5_6(operation, precision, rounding_mode, test_f, cover_f)
-                tests_fma_7_8(operation, precision, rounding_mode, test_f, cover_f)
-                tests_fma_9(operation, precision, rounding_mode, test_f, cover_f)
+                tests_fma_1_2(operation, precision, rounding_mode, test_f, cover_f, config)
+                tests_fma_3_4(operation, precision, rounding_mode, test_f, cover_f, config)
+                tests_fma_5_6(operation, precision, rounding_mode, test_f, cover_f, config)
+                tests_fma_7_8(operation, precision, rounding_mode, test_f, cover_f, config)
+                tests_fma_9(operation, precision, rounding_mode, test_f, cover_f, config)
 
 
 def div_grs_mant(
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
     grs: str,
     g_bit_pos: int,
     precision: str,
@@ -1032,7 +1136,10 @@ def div_grs_mant(
     b_fp = generate_FP(e_bits, str(b_sign), b_exp_norm, b, e_bias)
 
     run_and_store_test_vector(
-        f"{OP_DIV}_{rounding_mode}_{b_fp}_{a_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+        f"{OP_DIV}_{rounding_mode}_{b_fp}_{a_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
+        test_f,
+        cover_f,
+        config,
     )
     return a_fp, b_fp
 
@@ -1107,7 +1214,7 @@ def getDivTests(precision: str, rounding_mode: str) -> Iterator[tuple[str, str]]
     yield from tests_div_9(precision, rounding_mode)
 
 
-def divTests(test_f: TextIO, cover_f: TextIO) -> None:
+def divTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for precision in FLOAT_FMTS:
         for rounding_mode in ROUNDING_MODES:
             for a, b in getDivTests(precision, rounding_mode):
@@ -1115,10 +1222,11 @@ def divTests(test_f: TextIO, cover_f: TextIO) -> None:
                     f"{OP_DIV}_{rounding_mode}_{a}_{b}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
                     test_f,
                     cover_f,
+                    config,
                 )
 
 
-def tests_add_sub_1_2(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_add_sub_1_2(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     m_bits = MANTISSA_BITS[precision]
     e_bits = EXPONENT_BITS[precision]
     e_bias = EXPONENT_BIAS[precision]
@@ -1148,11 +1256,14 @@ def tests_add_sub_1_2(precision: str, rounding_mode: str, test_f: TextIO, cover_
         a_fp = generate_FP(e_bits, sign, sn_exp, a, e_bias)
         b_fp = generate_FP(e_bits, sign, sn_exp, b, e_bias)
         run_and_store_test_vector(
-            f"{op}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+            f"{op}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
+            test_f,
+            cover_f,
+            config,
         )
 
 
-def tests_add_sub_3_4(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_add_sub_3_4(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     m_bits = MANTISSA_BITS[precision]
     e_bits = EXPONENT_BITS[precision]
     e_bias = EXPONENT_BIAS[precision]
@@ -1183,11 +1294,14 @@ def tests_add_sub_3_4(precision: str, rounding_mode: str, test_f: TextIO, cover_
         b_fp = generate_FP(e_bits, str(b_sign), sn_exp, b, e_bias)
 
         run_and_store_test_vector(
-            f"{op}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+            f"{op}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
+            test_f,
+            cover_f,
+            config,
         )
 
 
-def tests_add_sub_5_6(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_add_sub_5_6(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     m_bits = MANTISSA_BITS[precision]
     e_bits = EXPONENT_BITS[precision]
     e_bias = EXPONENT_BIAS[precision]
@@ -1208,6 +1322,7 @@ def tests_add_sub_5_6(precision: str, rounding_mode: str, test_f: TextIO, cover_
                 f"{OP_ADD}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
                 test_f,
                 cover_f,
+                config,
             )
         normDist += 1
 
@@ -1226,11 +1341,12 @@ def tests_add_sub_5_6(precision: str, rounding_mode: str, test_f: TextIO, cover_
                 f"{OP_SUB}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
                 test_f,
                 cover_f,
+                config,
             )
         normDist += 1
 
 
-def tests_add_sub_9(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO) -> None:
+def tests_add_sub_9(precision: str, rounding_mode: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     m_bits = MANTISSA_BITS[precision]
     e_bits = EXPONENT_BITS[precision]
     e_bias = EXPONENT_BIAS[precision]
@@ -1250,23 +1366,26 @@ def tests_add_sub_9(precision: str, rounding_mode: str, test_f: TextIO, cover_f:
             a_fp = generate_FP(e_bits, a_sign, a_exp, f"{a_mant:0{m_bits}b}", e_bias)
             b_fp = generate_FP(e_bits, b_sign, b_exp, f"{b_mant:0{m_bits}b}", e_bias)
             run_and_store_test_vector(
-                f"{op}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+                f"{op}_{rounding_mode}_{a_fp}_{b_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
+                test_f,
+                cover_f,
+                config,
             )
 
 
-def addSubTests(test_f: TextIO, cover_f: TextIO) -> None:
+def addSubTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for precision in FLOAT_FMTS:
         for rounding_mode in ROUNDING_MODES:
-            tests_add_sub_1_2(precision, rounding_mode, test_f, cover_f)
+            tests_add_sub_1_2(precision, rounding_mode, test_f, cover_f, config)
             # tests_add_sub_3_4(precision, rounding_mode, test_f, cover_f)
             # tests_add_sub_5_6(precision, rounding_mode, test_f, cover_f)
-            tests_add_sub_9(precision, rounding_mode, test_f, cover_f)
+            tests_add_sub_9(precision, rounding_mode, test_f, cover_f, config)
 
 
 @register_model("B5")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    convertTests(test_f, cover_f)  # Generating Too little tests
-    multiplyTests(test_f, cover_f)
-    addSubTests(test_f, cover_f)  # Generating too many tests
-    fmaTests(test_f, cover_f)
-    divTests(test_f, cover_f)
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    convertTests(test_f, cover_f, config)  # Generating Too little tests
+    multiplyTests(test_f, cover_f, config)
+    addSubTests(test_f, cover_f, config)  # Generating too many tests
+    fmaTests(test_f, cover_f, config)
+    divTests(test_f, cover_f, config)

--- a/src/cover_float/testgen/B6.py
+++ b/src/cover_float/testgen/B6.py
@@ -22,6 +22,7 @@ import random
 from random import seed
 from typing import TextIO
 
+from cover_float.common.config import Config
 from cover_float.common.constants import (
     EXPONENT_BIAS,
     EXPONENT_BITS,
@@ -105,6 +106,7 @@ def convert_grs(
     rounding_mode: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
     hashString: str,
 ) -> None:
     hashval = reproducible_hash(hashString)
@@ -152,7 +154,7 @@ def convert_grs(
 
     input_fp = generate_FP(hp_e_bits, sign, input_exp, input_mant_bin, hp_e_bias)
     run_and_store_test_vector(
-        f"{OP_CFF}_{rounding_mode}_{input_fp}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00", test_f, cover_f
+        f"{OP_CFF}_{rounding_mode}_{input_fp}_{32 * '0'}_{32 * '0'}_{hp}_{32 * '0'}_{lp}_00", test_f, cover_f, config
     )
 
 
@@ -346,6 +348,7 @@ def mul_div_grs_gen(
     sign: int,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
     hashEnding: str,
     genTests: bool,
 ) -> tuple[str, str]:
@@ -399,7 +402,10 @@ def mul_div_grs_gen(
 
     if genTests:
         run_and_store_test_vector(
-            f"{operation}_{rounding_mode}_{a}_{b}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+            f"{operation}_{rounding_mode}_{a}_{b}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
+            test_f,
+            cover_f,
+            config,
         )
 
     return (a, b)
@@ -415,6 +421,7 @@ def fma_gen(
     addend_pattern: str,
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
     hashEnding: str,
 ) -> None:
     m_bits = MANTISSA_BITS[precision]
@@ -463,6 +470,7 @@ def fma_gen(
         mul_sign,
         test_f,
         cover_f,
+        config,
         hashEnding,
         False,
     )
@@ -478,13 +486,14 @@ def fma_gen(
     c_bin_mant = f"{c_mant:0{m_bits}b}"
     c = generate_FP(e_bits, str(c_sign), c_exp, c_bin_mant, e_bias)
     run_and_store_test_vector(
-        f"{operation}_{rounding_mode}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+        f"{operation}_{rounding_mode}_{a}_{b}_{c}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f, config
     )
 
 
 def div_grs_mant(
     test_f: TextIO,
     cover_f: TextIO,
+    config: Config,
     grs: str,
     g_bit_pos: int,
     precision: str,
@@ -535,12 +544,15 @@ def div_grs_mant(
     b_fp = generate_FP(e_bits, str(b_sign), b_exp_norm, b, e_bias)
 
     run_and_store_test_vector(
-        f"{OP_DIV}_{rounding_mode}_{b_fp}_{a_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00", test_f, cover_f
+        f"{OP_DIV}_{rounding_mode}_{b_fp}_{a_fp}_{32 * '0'}_{precision}_{32 * '0'}_{precision}_00",
+        test_f,
+        cover_f,
+        config,
     )
     return a_fp, b_fp
 
 
-def convertTests(test_f: TextIO, cover_f: TextIO) -> None:
+def convertTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # All conversion tests:
     for i_hp in range(len(B6_FMTS)):
         hp = B6_FMTS[i_hp]
@@ -560,11 +572,11 @@ def convertTests(test_f: TextIO, cover_f: TextIO) -> None:
                     # Our targets are less than these numbers, so the exponents we wish to reach must be one fewer
                     for exp in [lp_min_sn_exp - 1, tlp_min_sn_exp - 1]:
                         hashString = str(hp) + str(lp) + str(rounding_mode) + str(grs) + str(exp)
-                        convert_grs(hp, lp, exp, bits, "0", rounding_mode, test_f, cover_f, hashString + "0")
-                        convert_grs(hp, lp, exp, bits, "1", rounding_mode, test_f, cover_f, hashString + "1")
+                        convert_grs(hp, lp, exp, bits, "0", rounding_mode, test_f, cover_f, config, hashString + "0")
+                        convert_grs(hp, lp, exp, bits, "1", rounding_mode, test_f, cover_f, config, hashString + "1")
 
 
-def createTests(test_f: TextIO, cover_f: TextIO) -> None:
+def createTests(test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     for rounding_mode in ROUNDING_MODES:
         for precision in B6_FMTS:
             # precision = FMT_HALF
@@ -580,10 +592,10 @@ def createTests(test_f: TextIO, cover_f: TextIO) -> None:
 
                     for grs_bin in grs:
                         mul_div_grs_gen(
-                            OP_MUL, precision, rounding_mode, grs_bin, exp, sign, test_f, cover_f, "1/2", True
+                            OP_MUL, precision, rounding_mode, grs_bin, exp, sign, test_f, cover_f, config, "1/2", True
                         )
                         mul_div_grs_gen(
-                            OP_DIV, precision, rounding_mode, grs_bin, exp, sign, test_f, cover_f, "1/2", True
+                            OP_DIV, precision, rounding_mode, grs_bin, exp, sign, test_f, cover_f, config, "1/2", True
                         )
                         for operation in FMA_OPS:
                             fma_gen(
@@ -596,11 +608,12 @@ def createTests(test_f: TextIO, cover_f: TextIO) -> None:
                                 "min_sn",
                                 test_f,
                                 cover_f,
+                                config,
                                 "pos_1",
                             )
 
 
 @register_model("B6")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
-    convertTests(test_f, cover_f)
-    createTests(test_f, cover_f)
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
+    convertTests(test_f, cover_f, config)
+    createTests(test_f, cover_f, config)

--- a/src/cover_float/testgen/B7.py
+++ b/src/cover_float/testgen/B7.py
@@ -28,6 +28,7 @@ import logging
 import random
 from typing import TYPE_CHECKING, Optional, TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 import cover_float.common.log as log
 from cover_float.common.util import (
@@ -49,7 +50,7 @@ else:
     from sympy import factorint
 
 
-def add_sub_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def add_sub_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     hashval = reproducible_hash(fmt + "add sub" + "b7")
     random.seed(hashval)
 
@@ -101,7 +102,7 @@ def add_sub_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             if int(rounding_bits, 2) != 1 << (nf - extra_bit - 1 + is_subtraction) and rounding_bits.count("1") == 1:
                 logger.exception(f"Add Sub Generation Failed: extra_bit: {extra_bit}, op: {op}")
             else:
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
 
 
 def mul_sigs_with_trailing(target: int, bit_length: int, fmt: str) -> tuple[int, int]:
@@ -121,7 +122,7 @@ def mul_sigs_with_trailing(target: int, bit_length: int, fmt: str) -> tuple[int,
     return (0, 0)
 
 
-def mul_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def mul_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     hashval = reproducible_hash(fmt + "mul" + "b7")
     random.seed(hashval)
 
@@ -182,10 +183,10 @@ def mul_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 continue  # This means guard is 1
 
             if expected_shift_left and not hit_with_shift:
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
                 hit_with_shift = True
             elif not expected_shift_left and not hit_without_shift:
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
                 hit_without_shift = True
 
             if hit_with_shift and hit_without_shift:
@@ -311,7 +312,7 @@ def cached_factorint(target: int) -> dict[int, int]:
     return factorint(target)
 
 
-def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     hashval = reproducible_hash(fmt + "fma" + "b7")
     random.seed(hashval)
 
@@ -435,7 +436,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 expected_extra_bits = expected_extra_bits.rstrip("0")
 
                 if actual_extra_bits == expected_extra_bits:
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
                     break
             else:
                 logger.exception("Failure to generate a Guard=0 Case in FMA Testgen")
@@ -494,7 +495,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 ):
                     continue
                 else:
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
                     break
             else:
                 logger.exception(
@@ -615,10 +616,10 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                     continue
                 elif placement not in placements:
                     placements.append(placement)
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
 
 
-def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # CFF
     nf = constants.MANTISSA_BITS[fmt]
     for from_fmt in constants.FLOAT_FMTS:
@@ -644,9 +645,9 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             rounding_bits = interm_mantissa[nf:]
 
             if rounding_bits == bin(extra_bits)[2:].zfill(from_nf - nf):
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
             elif fmt == "04" and constants.MANTISSA_BITS[fmt] + extra_bit >= 23:
-                store_cover_vector(result, test_f, cover_f)  # This is just a quirk of how bf16 converts work
+                store_cover_vector(result, test_f, cover_f, config)  # This is just a quirk of how bf16 converts work
             else:
                 logger.exception(f"CFF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bits: {extra_bits:b}")
 
@@ -676,7 +677,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             rounding_bits = interm_mantissa[to_bits : to_bits + frac_bits]
 
             if rounding_bits == bin(frac_part)[2:].zfill(frac_bits):
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
             else:
                 logger.exception(f"CFI Generation Failure From: {fmt}, To: {to_fmt}, Extra-Bits: {frac_part:b}")
 
@@ -704,7 +705,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
             rounding_bits = interm_mantissa[nf:]
 
             if rounding_bits.count("1") == 1 and rounding_bits.find("1") == extra_bit:
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
             elif (
                 from_fmt in [constants.FMT_INT, constants.FMT_UINT]
                 and fmt == constants.FMT_BF16
@@ -714,15 +715,15 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
                 and fmt == constants.FMT_BF16
                 and extra_bit + constants.MANTISSA_BITS[fmt] >= constants.MANTISSA_BITS[constants.FMT_DOUBLE]
             ):
-                store_cover_vector(result, test_f, cover_f)  # Softfloat quirk makes it not track correctly here
+                store_cover_vector(result, test_f, cover_f, config)  # Softfloat quirk makes it not track correctly here
             else:
                 logger.exception(f"CIF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bit: {extra_bit}")
 
 
 @register_model("B7")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
-        add_sub_tests(fmt, test_f, cover_f)
-        mul_tests(fmt, test_f, cover_f)
-        fma_tests(fmt, test_f, cover_f)
-        convert_tests(fmt, test_f, cover_f)
+        add_sub_tests(fmt, test_f, cover_f, config)
+        mul_tests(fmt, test_f, cover_f, config)
+        fma_tests(fmt, test_f, cover_f, config)
+        convert_tests(fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B7.py
+++ b/src/cover_float/testgen/B7.py
@@ -24,13 +24,11 @@
 #   This excludes DIV and SQRT as targeting specific sticky values is impossible
 
 import functools
-import logging
 import random
-from typing import TYPE_CHECKING, Optional, TextIO, cast
+from typing import TYPE_CHECKING, Optional, TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import (
     bezout_inverse,
     factors_to_bit_width,
@@ -39,9 +37,7 @@ from cover_float.common.util import (
     reproducible_hash,
 )
 from cover_float.reference import run_test_vector, store_cover_vector
-from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B7"))
+from cover_float.testgen.model import get_model_logger, register_model
 
 if TYPE_CHECKING:
     # This block is seen by Pyright but ignored at runtime
@@ -100,7 +96,7 @@ def add_sub_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> 
             rounding_bits = rounding_bits[: nf + is_subtraction]
 
             if int(rounding_bits, 2) != 1 << (nf - extra_bit - 1 + is_subtraction) and rounding_bits.count("1") == 1:
-                logger.exception(f"Add Sub Generation Failed: extra_bit: {extra_bit}, op: {op}")
+                raise ValueError(f"Add Sub Generation Failed: extra_bit: {extra_bit}, op: {op}")
             else:
                 store_cover_vector(result, test_f, cover_f, config)
 
@@ -192,7 +188,7 @@ def mul_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None
             if hit_with_shift and hit_without_shift:
                 break
         else:
-            logger.exception(
+            raise ValueError(
                 f"Failure to generate mul tests, fmt={fmt}, extra_bit={extra_bit}, hit_with_shift={hit_with_shift}, "
                 f"hit_without_shift={hit_without_shift}"
             )
@@ -439,7 +435,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None
                     store_cover_vector(result, test_f, cover_f, config)
                     break
             else:
-                logger.exception("Failure to generate a Guard=0 Case in FMA Testgen")
+                raise ValueError("Failure to generate a Guard=0 Case in FMA Testgen")
 
         # Now do the addend hanging off of the end of the mantissa
         # This will be the (2nf + 1)th extra bit
@@ -498,7 +494,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None
                     store_cover_vector(result, test_f, cover_f, config)
                     break
             else:
-                logger.exception(
+                raise ValueError(
                     f"Failure to generate big multiplication, small, far addend for fma with sticky = {overhang_extra}"
                     f" in fmt: {fmt}"
                 )
@@ -515,7 +511,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None
         # the leading one from the multiplication mantissa is in the lsb
         placements: list[int] = []
 
-        with logger.progress_bar(status=f"{fmt} FMA Target Placements", show_m_of_n=True) as pbar:
+        with get_model_logger("B7").progress_bar(status=f"{fmt} FMA Target Placements", show_m_of_n=True) as pbar:
             for target_placement in pbar.track(range(1, 2 * constants.MANTISSA_BITS[fmt] + 1)):
                 # We want the lowest possible exponent difference
                 shift_amount = max(3, target_placement - constants.MANTISSA_BITS[fmt] + 1)
@@ -612,8 +608,7 @@ def fma_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None
                 placement = actual_extra_bits.rfind("1")
 
                 if (placement != target_placement) or actual_extra_bits.count("1") != 1:
-                    logger.exception(f"Failed To Generate C +- Prod Cases for FMA, op={op}, target={target_placement}")
-                    continue
+                    raise ValueError(f"Failed To Generate C +- Prod Cases for FMA, op={op}, target={target_placement}")
                 elif placement not in placements:
                     placements.append(placement)
                     store_cover_vector(result, test_f, cover_f, config)
@@ -649,7 +644,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> 
             elif fmt == "04" and constants.MANTISSA_BITS[fmt] + extra_bit >= 23:
                 store_cover_vector(result, test_f, cover_f, config)  # This is just a quirk of how bf16 converts work
             else:
-                logger.exception(f"CFF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bits: {extra_bits:b}")
+                raise ValueError(f"CFF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bits: {extra_bits:b}")
 
     # CFI
     for to_fmt in constants.INT_FMTS:
@@ -679,7 +674,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> 
             if rounding_bits == bin(frac_part)[2:].zfill(frac_bits):
                 store_cover_vector(result, test_f, cover_f, config)
             else:
-                logger.exception(f"CFI Generation Failure From: {fmt}, To: {to_fmt}, Extra-Bits: {frac_part:b}")
+                raise ValueError(f"CFI Generation Failure From: {fmt}, To: {to_fmt}, Extra-Bits: {frac_part:b}")
 
     # CIF
     for from_fmt in constants.INT_FMTS:
@@ -717,7 +712,7 @@ def convert_tests(fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> 
             ):
                 store_cover_vector(result, test_f, cover_f, config)  # Softfloat quirk makes it not track correctly here
             else:
-                logger.exception(f"CIF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bit: {extra_bit}")
+                raise ValueError(f"CIF Generation Failure From: {from_fmt}, To: {fmt}, Extra-Bit: {extra_bit}")
 
 
 @register_model("B7")

--- a/src/cover_float/testgen/B8.py
+++ b/src/cover_float/testgen/B8.py
@@ -16,13 +16,11 @@
 # B8 (rwolk@hmc.edu)
 
 import itertools
-import logging
 import random
-from typing import Optional, TextIO, cast
+from typing import Optional, TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
-import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.common.util import (
     bezout_inverse,
     extract_rounding_info,
@@ -33,8 +31,6 @@ from cover_float.common.util import (
 )
 from cover_float.reference import run_and_store_test_vector, run_test_vector, store_cover_vector
 from cover_float.testgen.model import register_model
-
-logger: log.ModelLogger = cast(log.ModelLogger, logging.getLogger("B8"))
 
 
 def mul_sigs_with_trailing(target: int, bit_length: int, fmt: str) -> tuple[int, int]:
@@ -159,8 +155,7 @@ def generate_div_tests(
         for sign, lsb, guard in sign_lsb_guard():
             maybe_result = divideSetRounding(lsb, guard, target, target_bits, fmt)
             if not maybe_result:
-                logger.exception(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
-                continue
+                raise ValueError(f"Div Failure for lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
 
             s1, s2 = maybe_result
 
@@ -178,7 +173,7 @@ def generate_div_tests(
             if check_div_result(result, target, target_bits) and info["Guard"] == guard and info["LSB"] == lsb:
                 store_cover_vector(result, test_f, cover_f, config)
             else:
-                logger.exception(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
+                raise ValueError(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
 
 
 def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
@@ -213,7 +208,7 @@ def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, confi
                 run_and_store_test_vector(tv, test_f, cover_f, config)
                 break
             else:
-                logger.exception(
+                raise ValueError(
                     f"Mul Generation Failed: fmt={fmt}, lsb={lsb}, guard={guard}, extra_bits={target_sticky}"
                 )
 
@@ -293,7 +288,7 @@ def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, c
                 ):
                     store_cover_vector(result, test_f, cover_f, config)
                 else:
-                    logger.exception(
+                    raise ValueError(
                         f"Add/Sub Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb}, "
                         f"extra_bits:{target_sticky}"
                     )
@@ -382,7 +377,7 @@ def generate_fma_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, confi
                         store_cover_vector(result, test_f, cover_f, config)
                         break
                     else:
-                        logger.exception(
+                        raise ValueError(
                             f"FMA Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb},"
                             f" extra_bits:{sticky_target}"
                         )
@@ -452,7 +447,7 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, c
                 ) or (fmt == constants.FMT_QUAD and target_fmt == constants.FMT_BF16):
                     store_cover_vector(result, test_f, cover_f, config)
                 else:
-                    logger.exception(
+                    raise ValueError(
                         f"CFF/CFI Generation Failed, fmt={fmt}, target_fmt={target_fmt}, lsb={lsb}, guard={guard}, "
                         f"extra_bits={extra_bits:b}"
                     )
@@ -492,7 +487,7 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, c
                 ) or fmt == constants.FMT_BF16:
                     store_cover_vector(result, test_f, cover_f, config)
                 else:
-                    logger.exception(
+                    raise ValueError(
                         f"CIF Generation Failed, from_fmt={from_fmt}, fmt={fmt}, lsb={lsb}, guard={guard}, "
                         f"extra_bits={extra_bits:b}"
                     )

--- a/src/cover_float/testgen/B8.py
+++ b/src/cover_float/testgen/B8.py
@@ -20,6 +20,7 @@ import logging
 import random
 from typing import Optional, TextIO, cast
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 import cover_float.common.log as log
 from cover_float.common.util import (
@@ -144,7 +145,9 @@ def generate_exponents(fmt: str, *, subtract: bool = False) -> tuple[int, int]:
     return exp1, exp2
 
 
-def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, target_bits: Optional[int] = None) -> None:
+def generate_div_tests(
+    fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, config: Config, target_bits: Optional[int] = None
+) -> None:
     seed = reproducible_hash(f"B8 DIV {fmt} {rm}")
     random.seed(seed)
 
@@ -173,12 +176,12 @@ def generate_div_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, targe
             result = run_test_vector(tv)
             info = extract_rounding_info(result)
             if check_div_result(result, target, target_bits) and info["Guard"] == guard and info["LSB"] == lsb:
-                store_cover_vector(result, test_f, cover_f)
+                store_cover_vector(result, test_f, cover_f, config)
             else:
                 logger.exception(f"Div Result Failure, lsb={lsb}, guard={guard}, sticky={target:b}, fmt={fmt}")
 
 
-def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     seed = reproducible_hash(f"B8 MUL {fmt} {rm}")
     random.seed(seed)
 
@@ -207,7 +210,7 @@ def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                 f2 = generate_float(sign2, exp2, s2 & ((1 << nf) - 1), fmt)
 
                 tv = generate_test_vector(constants.OP_MUL, f1, f2, 0, fmt, fmt, rm)
-                run_and_store_test_vector(tv, test_f, cover_f)
+                run_and_store_test_vector(tv, test_f, cover_f, config)
                 break
             else:
                 logger.exception(
@@ -215,7 +218,7 @@ def generate_mul_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                 )
 
 
-def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     seed = reproducible_hash(f"B8 ADD SUB {fmt} {rm}")
     random.seed(seed)
     # To maximize the extra bits lengths, we know that we need to align one of the addends
@@ -288,7 +291,7 @@ def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                     rounding_bits[:total_rounding_bits] == target_bits
                     and rounding_bits[total_rounding_bits:].count("1") == 0
                 ):
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
                 else:
                     logger.exception(
                         f"Add/Sub Generation Failed, fmt={fmt}, op={op}, guard={guard}, lsb={lsb}, "
@@ -296,7 +299,7 @@ def generate_add_sub_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                     )
 
 
-def generate_fma_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_fma_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     seed = reproducible_hash(f"B8 FMA {fmt} {rm}")
     random.seed(seed)
 
@@ -376,7 +379,7 @@ def generate_fma_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                         rounding_bits[:total_rounding_bits] == target_bits
                         and rounding_bits[total_rounding_bits:].count("1") == 0
                     ):
-                        store_cover_vector(result, test_f, cover_f)
+                        store_cover_vector(result, test_f, cover_f, config)
                         break
                     else:
                         logger.exception(
@@ -385,7 +388,7 @@ def generate_fma_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> No
                         )
 
 
-def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -> None:
+def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     # These are pretty simple, we just want the maximum possible overhang for each type of conversion
     nf = constants.MANTISSA_BITS[fmt]
     exp_min, exp_max = constants.BIASED_EXP[fmt]
@@ -447,7 +450,7 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 if (
                     int(rounding_bits, 2) == target and rounding_bits[target_nf + maximal_overhang :].count("1") == 0
                 ) or (fmt == constants.FMT_QUAD and target_fmt == constants.FMT_BF16):
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
                 else:
                     logger.exception(
                         f"CFF/CFI Generation Failed, fmt={fmt}, target_fmt={target_fmt}, lsb={lsb}, guard={guard}, "
@@ -487,7 +490,7 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
                 if (
                     int(rounding_bits, 2) == target and rounding_bits[from_bits:].count("1") == 0
                 ) or fmt == constants.FMT_BF16:
-                    store_cover_vector(result, test_f, cover_f)
+                    store_cover_vector(result, test_f, cover_f, config)
                 else:
                     logger.exception(
                         f"CIF Generation Failed, from_fmt={from_fmt}, fmt={fmt}, lsb={lsb}, guard={guard}, "
@@ -496,11 +499,11 @@ def generate_convert_tests(fmt: str, rm: str, test_f: TextIO, cover_f: TextIO) -
 
 
 @register_model("B8")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
         for rm in constants.ROUNDING_MODES:
-            generate_div_tests(fmt, rm, test_f, cover_f)
-            generate_mul_tests(fmt, rm, test_f, cover_f)
-            generate_add_sub_tests(fmt, rm, test_f, cover_f)
-            generate_fma_tests(fmt, rm, test_f, cover_f)
-            generate_convert_tests(fmt, rm, test_f, cover_f)
+            generate_div_tests(fmt, rm, test_f, cover_f, config)
+            generate_mul_tests(fmt, rm, test_f, cover_f, config)
+            generate_add_sub_tests(fmt, rm, test_f, cover_f, config)
+            generate_fma_tests(fmt, rm, test_f, cover_f, config)
+            generate_convert_tests(fmt, rm, test_f, cover_f, config)

--- a/src/cover_float/testgen/B9.py
+++ b/src/cover_float/testgen/B9.py
@@ -20,6 +20,7 @@ import random
 from pathlib import Path
 from typing import TextIO
 
+from cover_float.common.config import Config
 import cover_float.common.constants as constants
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
@@ -193,7 +194,7 @@ class B9SignificandGenerator:
             file.write(f"bins bin_{i:02d} = {{ 'b{sig.zfill(self.nf)} }}; \n")
 
 
-def B9_generator(sigs: list[str], fmt: str, test_f: TextIO, cover_f: TextIO) -> None:
+def B9_generator(sigs: list[str], fmt: str, test_f: TextIO, cover_f: TextIO, config: Config) -> None:
     exp_min, exp_max = constants.BIASED_EXP[fmt]
     exp_max -= constants.BIAS[fmt]
     exp_min -= constants.BIAS[fmt]
@@ -215,14 +216,14 @@ def B9_generator(sigs: list[str], fmt: str, test_f: TextIO, cover_f: TextIO) -> 
                 float2 = generate_float(sign2, exp2, int(sig2, 2), fmt) if op not in B9_1SRC else 0
 
                 tv = generate_test_vector(op, float1, float2, 0, fmt, fmt, random.choice(constants.ROUNDING_MODES))
-                run_and_store_test_vector(tv, test_f, cover_f)
+                run_and_store_test_vector(tv, test_f, cover_f, config)
 
                 if op in B9_1SRC:
                     break  # Don't over generate tests
 
 
 @register_model("B9")
-def main(test_f: TextIO, cover_f: TextIO) -> None:
+def main(config: Config, test_f: TextIO, cover_f: TextIO) -> None:
     for fmt in constants.FLOAT_FMTS:
         generator = B9SignificandGenerator(constants.MANTISSA_BITS[fmt], fmt + "b9")
 
@@ -237,4 +238,4 @@ def main(test_f: TextIO, cover_f: TextIO) -> None:
 
         with bins_path.open("w") as generated_coverage:
             sigs = generator.generate(generated_coverage)
-            B9_generator(sigs, fmt, test_f, cover_f)
+            B9_generator(sigs, fmt, test_f, cover_f, config)

--- a/src/cover_float/testgen/B9.py
+++ b/src/cover_float/testgen/B9.py
@@ -20,8 +20,8 @@ import random
 from pathlib import Path
 from typing import TextIO
 
-from cover_float.common.config import Config
 import cover_float.common.constants as constants
+from cover_float.common.config import Config
 from cover_float.common.util import generate_float, generate_test_vector, reproducible_hash
 from cover_float.reference import run_and_store_test_vector
 from cover_float.testgen.model import register_model

--- a/src/cover_float/testgen/__init__.py
+++ b/src/cover_float/testgen/__init__.py
@@ -17,6 +17,6 @@ from cover_float.testgen.discover_models import discover_and_import_models
 from cover_float.testgen.model import GLOBAL_MODELS
 
 __all__ = [
-    "discover_and_import_models",
     "GLOBAL_MODELS",
+    "discover_and_import_models",
 ]

--- a/src/cover_float/testgen/discover_models.py
+++ b/src/cover_float/testgen/discover_models.py
@@ -13,10 +13,12 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from cover_float.testgen.discover_models import discover_and_import_models
-from cover_float.testgen.model import GLOBAL_MODELS
+from pathlib import Path
+from importlib import import_module
 
-__all__ = [
-    "discover_and_import_models",
-    "GLOBAL_MODELS",
-]
+def discover_and_import_models() -> None:
+    model_dir = Path(__file__).parent
+
+    for py_file in model_dir.glob("*.py"):
+        if py_file.stem.startswith("B"):
+            import_module(f"cover_float.testgen.{py_file.stem}")

--- a/src/cover_float/testgen/discover_models.py
+++ b/src/cover_float/testgen/discover_models.py
@@ -13,8 +13,9 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from pathlib import Path
 from importlib import import_module
+from pathlib import Path
+
 
 def discover_and_import_models() -> None:
     model_dir = Path(__file__).parent

--- a/src/cover_float/testgen/model.py
+++ b/src/cover_float/testgen/model.py
@@ -22,14 +22,15 @@ import logging
 import logging.handlers
 import os
 import re
+from collections.abc import Generator
 from pathlib import Path
 from queue import Queue
-from typing import Any, Callable, TextIO, Generator
+from typing import Any, Callable, TextIO
 
 from rich.progress import TaskID
 
-from cover_float.common.config import Config
 import cover_float.common.log as log
+from cover_float.common.config import Config
 from cover_float.scripts.postprocess import postprocess_testvectors
 
 GLOBAL_MODELS: dict[
@@ -38,6 +39,8 @@ GLOBAL_MODELS: dict[
 GLOBAL_MODEL_FUNCTIONS: dict[str, Callable[[Config, TextIO, TextIO], None]] = {}
 
 PARTIAL_OUTPUT_MESSAGE = "# Generated With --partial-output\n"
+
+_MODEL_LOGGERS: dict[str, log.ModelAdapter] = {}
 
 
 class MPLoggingHandler(logging.Handler):
@@ -58,6 +61,10 @@ class MPLoggingHandler(logging.Handler):
         )
 
 
+def get_model_logger(model: str) -> log.ModelAdapter:
+    return _MODEL_LOGGERS[model]
+
+
 def _run_model_by_name(
     model_name: str,
     config: Config,
@@ -70,23 +77,16 @@ def _run_model_by_name(
     tv_stamp_path = config.output_dir / ".stamp" / f"{model_name}_tv.stamp"
     cv_stamp_path = config.output_dir / ".stamp" / f"{model_name}_cv.stamp"
 
-    model_logger = logging.getLogger(model_name)
-
-    if isinstance(model_logger, log.ModelLogger):
-        model_logger.task_id = task_id
-        model_logger.msg_queue = logging_queue
+    model_logger = logging.getLogger(__name__ + " " + model_name)
+    model_logger_adapter = log.ModelAdapter(model_logger, task_id, logging_queue)
+    _MODEL_LOGGERS[model_name] = model_logger_adapter
 
     model_logger.handlers = []
     model_logger.propagate = False
-
-    # Handle Status Updates
-    handler = MPLoggingHandler(logging_queue, task_id)
-    handler.addFilter(log.OnlyStatusFilter())
-    model_logger.addHandler(handler)
+    model_logger.setLevel(log.log_level_from_config(config))
 
     # Handle Other Updates
     general_handler = logging.handlers.QueueHandler(logging_queue)
-    general_handler.addFilter(log.ExcludeStatusFilter())
     model_logger.addHandler(general_handler)
 
     try:
@@ -100,16 +100,17 @@ def _run_model_by_name(
             test_vectors_dir = config.output_dir / "testvectors"
             readable_vectors_dir = config.output_dir / "readable"
             processed_vectors_dir = config.output_dir / "processed"
-            postprocess_testvectors(model_name, model_logger_adapter, test_vectors_dir, processed_vectors_dir, readable_vectors_dir, config)
+            postprocess_testvectors(
+                model_name, model_logger_adapter, test_vectors_dir, processed_vectors_dir, readable_vectors_dir, config
+            )
 
         tv_stamp_path.parent.mkdir(parents=True, exist_ok=True)
         tv_stamp_path.touch()
         if not config.release:
             cv_stamp_path.parent.mkdir(parents=True, exist_ok=True)
             cv_stamp_path.touch()
-    except Exception as e:
-        logger = logging.getLogger(model_name)
-        logger.exception(f"[bold red]Fatal Error in {model_name}[/] ", exc_info=e, extra={"markup": True})
+    except Exception:
+        model_logger.exception(f"[bold red]Fatal Error in {model_name}[/] ", extra={"markup": True})
         return False
     return True
 

--- a/src/cover_float/testgen/model.py
+++ b/src/cover_float/testgen/model.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import functools
 import inspect
 import logging
 import logging.handlers
@@ -23,18 +24,18 @@ import os
 import re
 from pathlib import Path
 from queue import Queue
-from typing import Any, Callable, TextIO
+from typing import Any, Callable, TextIO, Generator
 
 from rich.progress import TaskID
 
-import cover_float.common.constants as constants
+from cover_float.common.config import Config
 import cover_float.common.log as log
 from cover_float.scripts.postprocess import postprocess_testvectors
 
 GLOBAL_MODELS: dict[
-    str, Callable[[Path, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[bool] | None]
+    str, Callable[[Config, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[bool] | None]
 ] = {}
-GLOBAL_MODEL_FUNCTIONS: dict[str, Callable[[TextIO, TextIO], None]] = {}
+GLOBAL_MODEL_FUNCTIONS: dict[str, Callable[[Config, TextIO, TextIO], None]] = {}
 
 PARTIAL_OUTPUT_MESSAGE = "# Generated With --partial-output\n"
 
@@ -59,15 +60,15 @@ class MPLoggingHandler(logging.Handler):
 
 def _run_model_by_name(
     model_name: str,
-    output_dir: Path,
+    config: Config,
     task_id: TaskID,
     logging_queue: Queue[Any],
     post_process: bool,
 ) -> bool:
-    tv_path = output_dir / "testvectors" / f"{model_name}_tv.txt"
-    cv_path = output_dir / "covervectors" / f"{model_name}_cv.txt" if not constants.config.RELEASE else Path(os.devnull)
-    tv_stamp_path = output_dir / ".stamp" / f"{model_name}_tv.stamp"
-    cv_stamp_path = output_dir / ".stamp" / f"{model_name}_cv.stamp"
+    tv_path = config.output_dir / "testvectors" / f"{model_name}_tv.txt"
+    cv_path = config.output_dir / "covervectors" / f"{model_name}_cv.txt" if not config.release else Path(os.devnull)
+    tv_stamp_path = config.output_dir / ".stamp" / f"{model_name}_tv.stamp"
+    cv_stamp_path = config.output_dir / ".stamp" / f"{model_name}_cv.stamp"
 
     model_logger = logging.getLogger(model_name)
 
@@ -90,20 +91,20 @@ def _run_model_by_name(
 
     try:
         with tv_path.open("w") as test_f, cv_path.open("w") as cover_f:
-            if not constants.config.FULL_COVERAGE_TESTGEN:
+            if not config.full_coverage_testgen:
                 test_f.write(PARTIAL_OUTPUT_MESSAGE)
                 cover_f.write(PARTIAL_OUTPUT_MESSAGE)
-            GLOBAL_MODEL_FUNCTIONS[model_name](test_f, cover_f)
+            GLOBAL_MODEL_FUNCTIONS[model_name](config, test_f, cover_f)
 
         if post_process:
-            test_vectors_dir = output_dir / "testvectors"
-            readable_vectors_dir = output_dir / "readable"
-            processed_vectors_dir = output_dir / "processed"
-            postprocess_testvectors(model_name, test_vectors_dir, processed_vectors_dir, readable_vectors_dir)
+            test_vectors_dir = config.output_dir / "testvectors"
+            readable_vectors_dir = config.output_dir / "readable"
+            processed_vectors_dir = config.output_dir / "processed"
+            postprocess_testvectors(model_name, model_logger_adapter, test_vectors_dir, processed_vectors_dir, readable_vectors_dir, config)
 
         tv_stamp_path.parent.mkdir(parents=True, exist_ok=True)
         tv_stamp_path.touch()
-        if not constants.config.RELEASE:
+        if not config.release:
             cv_stamp_path.parent.mkdir(parents=True, exist_ok=True)
             cv_stamp_path.touch()
     except Exception as e:
@@ -113,41 +114,51 @@ def _run_model_by_name(
     return True
 
 
+def get_supporting_sources(base_dir: Path) -> Generator[Path, None, None]:
+    exts = ["py", "c", "h", "cpp", "hpp"]
+    for ext in exts:
+        yield from base_dir.rglob(f"*.{ext}")
+
+
+@functools.cache
+def get_max_supporting_mod_time() -> float:
+    max_supporting_mod_time = 0
+    for file in get_supporting_sources(Path(__file__).resolve().parent.parent.parent):
+        if not re.match(r"^B\d+\.py", file.name):
+            max_supporting_mod_time = max(max_supporting_mod_time, file.stat().st_mtime)
+    return max_supporting_mod_time
+
+
 def register_model(
     model_name: str,
 ) -> Callable[
-    [Callable[[TextIO, TextIO], None]],
-    Callable[[Path, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[bool] | None],
+    [Callable[[Config, TextIO, TextIO], None]],
+    Callable[[Config, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[bool] | None],
 ]:
     def inner(
-        fn: Callable[[TextIO, TextIO], None],
-    ) -> Callable[[Path, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[bool] | None]:
+        fn: Callable[[Config, TextIO, TextIO], None],
+    ) -> Callable[[Config, log.StatusReporter, concurrent.futures.Executor], concurrent.futures.Future[bool] | None]:
         # Store the function in a global dict so it can be accessed by the worker process
         GLOBAL_MODEL_FUNCTIONS[model_name] = fn
         source_file = Path(inspect.getfile(fn))
 
         def wrapper(
-            output_dir: Path,
+            config: Config,
             status_reporter: log.StatusReporter,
             executor: concurrent.futures.Executor,
             post_process: bool = True,
         ) -> concurrent.futures.Future[bool] | None:
             # Check modification of source files
-            cover_float_sources = Path(__file__).parent.parent.rglob("*.py")
-            max_supporting_mod_time = 0
-            for file in cover_float_sources:
-                if not re.match(r"^B\d+\.py", file.name):
-                    max_supporting_mod_time = max(max_supporting_mod_time, file.stat().st_mtime)
-
+            max_supporting_mod_time = get_max_supporting_mod_time()
             source_mod_time = source_file.stat().st_mtime
 
             # Check generation time of target files
-            tv_path = output_dir / "testvectors" / f"{model_name}_tv.txt"
-            tv_stamp_path = output_dir / ".stamp" / f"{model_name}_tv.stamp"
+            tv_path = config.output_dir / "testvectors" / f"{model_name}_tv.txt"
+            tv_stamp_path = config.output_dir / ".stamp" / f"{model_name}_tv.stamp"
             tv_mod_time = tv_stamp_path.stat().st_mtime if tv_stamp_path.exists() else 0
 
-            cv_path = output_dir / "covervectors" / f"{model_name}_cv.txt"
-            cv_stamp_path = output_dir / ".stamp" / f"{model_name}_cv.stamp"
+            cv_path = config.output_dir / "covervectors" / f"{model_name}_cv.txt"
+            cv_stamp_path = config.output_dir / ".stamp" / f"{model_name}_cv.stamp"
             cv_mod_time = cv_stamp_path.stat().st_mtime if cv_stamp_path.exists() else 0
 
             tv_comes_from_partial: bool | None = None
@@ -163,23 +174,23 @@ def register_model(
                     cv_comes_from_partial = first_line == PARTIAL_OUTPUT_MESSAGE
 
             if (
-                not constants.config.RELEASE
+                not config.release
                 and (
                     (source_mod_time > cv_mod_time)
                     or (max_supporting_mod_time > cv_mod_time)
-                    or (cv_comes_from_partial != (not constants.config.FULL_COVERAGE_TESTGEN))
+                    or (cv_comes_from_partial != (not config.full_coverage_testgen))
                 )
             ) or (
                 (source_mod_time > tv_mod_time)
                 or (max_supporting_mod_time > tv_mod_time)
-                or (tv_comes_from_partial != (not constants.config.FULL_COVERAGE_TESTGEN))
+                or (tv_comes_from_partial != (not config.full_coverage_testgen))
             ):
                 task_id = status_reporter.start_model(model_name)
 
                 future = executor.submit(
                     _run_model_by_name,
                     model_name,
-                    output_dir,
+                    config,
                     task_id,
                     status_reporter.logging_queue,
                     post_process,

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "rich", specifier = "==14.1.0" },
+    { name = "rich", specifier = ">=14.3.4" },
     { name = "sympy", specifier = "==1.14.0" },
 ]
 
@@ -312,16 +312,16 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.1.0"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In this PR, we
- Refactor logging so that it doesn't have any side effects on the root logging infrastructure
- Clean up `pyproject.toml` so that it is compatible with `riscv-arch-test` by bumping `rich`
- Get rid of the unused reference model frontend
- Expose the generation logic as its own function that takes a config as an argument that is either generate in code, or through the cli
- Add a module discovery mechanism to not rely on `__init__` importing things so that the registry functions are run. 